### PR TITLE
Resize images

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -80,6 +80,15 @@ other = "Palette"
 one = "{{ .Count }} Beitrag insgesamt"
 other = "{{ .Count }} Beiträge insgesamt"
 
+[post_created_on]
+other = "erstellt am"
+
+[post_reading_time]
+other = "Lesezeit"
+
+[post_updated_on]
+other = "aktualisiert am"
+
 [reading_time]
 one = "{{ .ReadingTime }} Minute Lesezeit"
 other = "{{ .ReadingTime }} Minuten Lesezeit"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -80,6 +80,15 @@ other = "Palette"
 one = "{{ .Count }} post in total"
 other = "{{ .Count }} posts in total"
 
+[post_created_on]
+other = "created on"
+
+[post_reading_time]
+other = "reading time"
+
+[post_updated_on]
+other = "updated on"
+
 [reading_time]
 other = "{{ .ReadingTime }} min read"
 

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -62,4 +62,4 @@
 
 <img class="{{ $className }}" alt="{{ .alt }}" src="{{ $link }}" loading="lazy"
   {{ with $img }} width="{{ $img.Width }}" height="{{ $img.Height }}"{{ end }}
-  {{ if or $width $height }}style="{{ with $width }}width: {{ $width }}{{ end }}{{ with $height }};height: {{ $height }}{{ end }}"{{ end }} />
+  {{ if and (not $pageResource) (or $width $height) }}style="{{ with $width }}width: {{ $width }}{{ end }}{{ with $height }};height: {{ $height }}{{ end }}"{{ end }} />

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -47,17 +47,17 @@
   <!-- Resize to actual entered size -->
   {{- $resize := (printf "%sx%s" (strings.TrimSuffix "px" $width) (strings.TrimSuffix "px" $height)) -}}
   {{- $img = $img.Resize $resize -}}
-  {{- $link = $img.RelPermalink | safeURL -}}
+  {{- $link = $img.Permalink | safeURL -}}
 {{- else if and (ne $width false) $pageResource }}
   <!-- Resize width to entered size, keeping aspect ratio -->
   {{- $resize := (printf "%sx" (strings.TrimSuffix "px" $width)) -}}
   {{- $img = $img.Resize $resize -}}
-  {{- $link = $img.RelPermalink | safeURL -}}
+  {{- $link = $img.Permalink | safeURL -}}
 {{- else if and (ne $height false) $pageResource }}
   <!-- Resize height to entered size, keeping aspect ratio -->
   {{- $resize := (printf "x%s" (strings.TrimSuffix "px" $height)) -}}
   {{- $img = $img.Resize $resize -}}
-  {{- $link = $img.RelPermalink | safeURL -}}
+  {{- $link = $img.Permalink | safeURL -}}
 {{- end -}}
 
 <img class="{{ $className }}" alt="{{ .alt }}" src="{{ $link }}" loading="lazy"

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -1,6 +1,7 @@
 {{- $img := false -}}
 {{- $width := false -}}
 {{- $height := false -}}
+{{- $pageResource := false -}}
 {{- $link := "" -}}
 {{- $url := urls.Parse .filename -}}
 {{- if not $url.Scheme -}}
@@ -8,6 +9,7 @@
   {{- if $resource -}}
     {{- $img = $resource -}}
     {{- $link = $resource.Permalink -}}
+    {{- $pageResource = true -}}
   {{- else -}}
     {{- $filename := path.Join "static" $url.Path -}}
     {{- if fileExists $filename -}}
@@ -34,12 +36,30 @@
 {{- end -}}
 {{- $className := default "img-fluid" .class -}}
 {{- if eq $url.Fragment "center" -}}
-{{- $className = printf "%s %s" $className "mx-auto d-block" -}}
+  {{- $className = printf "%s %s" $className "mx-auto d-block" -}}
 {{- else if eq $url.Fragment "floatleft" -}}
-{{- $className = printf "%s %s" $className "float-start me-2" -}}
+  {{- $className = printf "%s %s" $className "float-start me-2" -}}
 {{- else if eq $url.Fragment "floatright" -}}
   {{- $className = printf "%s %s" $className "float-end ms-2" -}}
 {{- end -}}
+
+{{- if and $width $height $pageResource -}}
+  <!-- Resize to actual entered size -->
+  {{- $resize := (printf "%sx%s" (strings.TrimSuffix "px" $width) (strings.TrimSuffix "px" $height)) -}}
+  {{- $img = $img.Resize $resize -}}
+  {{- $link = $img.RelPermalink | safeURL -}}
+{{- else if and (ne $width false) $pageResource }}
+  <!-- Resize width to entered size, keeping aspect ratio -->
+  {{- $resize := (printf "%sx" (strings.TrimSuffix "px" $width)) -}}
+  {{- $img = $img.Resize $resize -}}
+  {{- $link = $img.RelPermalink | safeURL -}}
+{{- else if and (ne $height false) $pageResource }}
+  <!-- Resize height to entered size, keeping aspect ratio -->
+  {{- $resize := (printf "x%s" (strings.TrimSuffix "px" $height)) -}}
+  {{- $img = $img.Resize $resize -}}
+  {{- $link = $img.RelPermalink | safeURL -}}
+{{- end -}}
+
 <img class="{{ $className }}" alt="{{ .alt }}" src="{{ $link }}" loading="lazy"
   {{ with $img }} width="{{ $img.Width }}" height="{{ $img.Height }}"{{ end }}
   {{ if or $width $height }}style="{{ with $width }}width: {{ $width }}{{ end }}{{ with $height }};height: {{ $height }}{{ end }}"{{ end }} />

--- a/layouts/partials/post/meta.html
+++ b/layouts/partials/post/meta.html
@@ -1,17 +1,17 @@
 <div class="post-meta">
   {{- if and (default true (default .Site.Params.postDate .Params.postDate)) -}}
-  <span class="post-date">
+  <span class="post-date" title="{{ i18n "post_created_on" }}">
     <i class="fas fa-fw fa-calendar-alt"></i>{{ .Date.Format (default "Jan 2, 2006" $.Site.Params.dateFormat) }}
   </span>
   {{- end -}}
   {{ if gt .Lastmod .Date }}
-  <span class="post-date me-2">
+  <span class="post-date me-2" title="{{ i18n "post_updated_on" }}">
       <i class="fas fa-sync-alt"></i>
       {{ .Lastmod.Format (default "Jan 2, 2006" $.Site.Params.dateFormat) }}
     </span>
   {{ end }}
   {{- if and (default true (default .Site.Params.readingTime .Params.readingTime)) -}}
-  <span class="post-reading-time">
+  <span class="post-reading-time" title="{{ i18n "post_reading_time" }}">
     <i class="fas fa-fw fa-coffee"></i>{{ i18n "reading_time" . }}
   </span>
   {{- end -}}


### PR DESCRIPTION
Add support for resizing images using Hugos [Image processing](https://gohugo.io/content-management/image-processing/) to get smaller image sizes.

Edit: Forgot to mention that this works only for [pageResources](https://gohugo.io/content-management/page-resources/). When an image is not found as pageResource it will not resize it just style it as earlier.

I have tried testing it with different cases and it seems to work, but I don't know if there is some case which doesn't work.