### PR TITLE
Correcting issue with loading pwa manifest.json when there is only a …

### DIFF
--- a/assets/service-worker/config.js
+++ b/assets/service-worker/config.js
@@ -10,9 +10,13 @@
 
 {{- partial "helpers/read-dir" (dict "Path" "/static" "Scratch" $.Scratch) -}}
 
+{{ if eq (len .Sites) 1 }}
+  {{- $pages = $pages | append (dict "url" (printf "/%s" "manifest.json" | absURL) "revision" $defaultRivision)  -}}
+{{ else }}
 {{- range $.Site.Languages -}}
   {{- $pages = $pages | append (dict "url" (printf "/%s/%s" .Lang "manifest.json" | absURL) "revision" $defaultRivision)  -}}
 {{- end -}}
+{{ end }}
 
 const pages = JSON.parse('{{ $pages | jsonify }}');
 const assets = JSON.parse('{{ $.Scratch.Get "hbs-assets" | jsonify }}');


### PR DESCRIPTION
…single language on the site

I'm currently running into issues on my site https://benjiv.com where the service-worker is unable to load properly because the language is being appended to the path for the manifest.json file even though there is only a single language and hugo is generating the manifest.json into the root of the site. 

This fix corrects the issue for single-language sites.