### PR TITLE
Example site: correct rendering of subscript, superscript and other raw html markup

### DIFF
--- a/exampleSite/config/_default/markup.toml
+++ b/exampleSite/config/_default/markup.toml
@@ -30,5 +30,5 @@ title = true
 
 [goldmark.renderer]
 hardWraps = false
-unsafe = false
+unsafe = true
 xhtml = false


### PR DESCRIPTION
**Example site, [Markdown Syntax Guide](https://hbs.razonyang.com/en/posts/markdown-syntax/):**

Last chapter `Other Elements — abbr, sub, sup, kbd, mark`

Terms like H<sub>2</sub>O are rendered incorrectly since by default, hugo's default renderer `goldmark` scrubs raw html tags for security reasons (see hugo's [documentation](https://gohugo.io/getting-started/configuration-markup#goldmark) on this topic). This PR corrects this incorrect rendering.

