### PR TITLE
Feature link title

### DIFF
--- a/layouts/partials/docs/catalog.html
+++ b/layouts/partials/docs/catalog.html
@@ -25,7 +25,7 @@
         {{- end -}}
         <li class="mb-2{{ if eq .Permalink $page.Permalink }} active{{ end }}" tabindex="-1">
           <div class="catalog-section bg-accent text-white px-2 py-1 d-flex justify-content-between align-items-center">
-            <a href="{{ .Permalink }}">{{ .Name }}</a>
+            <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
             <a class="btn-toggle collapsed ms-1" role="button" data-bs-toggle="collapse"
               data-bs-target="#{{ $sectionId }}" aria-expanded="{{ if $active }}true{{ else }}false{{ end }}" aria-controls="{{ $sectionId }}">
               <i class="btn-toggle-icon fas fa-arrow-left ms-auto" data-fa-transform="rotate-180"></i>
@@ -40,7 +40,7 @@
         {{- else -}}
         <li class="mb-2{{ if eq .Permalink $page.Permalink }} active text-accent{{ end }}" tabindex="-1">
           <a href="{{ .Permalink }}"{{ if .Params.redirect }} target="_blank"{{ end }}>
-            {{- .Title -}}
+            {{- .LinkTitle -}}
             {{- if .Params.redirect -}}
               <i class="ms-1 fas fa-external-link-alt"></i>
             {{- end -}}

--- a/layouts/partials/sidebar/profile/meta.html
+++ b/layouts/partials/sidebar/profile/meta.html
@@ -13,11 +13,11 @@
 <div class="profile-about"><i class="fas fa-fw fa-user"></i><a target="_blank" rel="noopener noreferrer" href="{{ .about }}">{{ i18n "about_me" }}</a></div>
 {{- else -}}
 {{- with $.GetPage "about" -}}
-<div class="profile-about"><i class="fas fa-fw fa-user"></i><a href="{{ .Permalink }}">{{ .Title }}</a></div>
+<div class="profile-about"><i class="fas fa-fw fa-user"></i><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></div>
 {{- end -}}
 {{- end -}}
 {{- with $.GetPage "contact" -}}
-<div class="profile-contact"><i class="fas fa-fw fa-question-circle"></i><a href="{{ .Permalink }}">{{ .Title }}</a></div>
+<div class="profile-contact"><i class="fas fa-fw fa-question-circle"></i><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></div>
 {{- end -}}
 {{- with .social -}}
 {{- partial "helpers/social-links" (dict "links" . "size" "fa-2x" "OutputFormats" $.OutputFormats) -}}


### PR DESCRIPTION
This feature allows specifying the text of link to the content, the `Title` will be used if the `linkTitle` is not set. It's useful that if you want to make the link text shorter. Of course, you could change the title directly, but it'll make the title ambiguous on list pages and SEO results.

Content:

```toml
// docs/installation/_index.md
title = "Installation"

// docs/installation/git-submodule.md
title = "Install via Git Submodule"
linkTitle = "Git Submodule"

// docs/installation/go-module.md
title = "Install via Go Module"
linkTitle = "Go Module"
```

Catalog:

```text
Installation
  - Git Submodule
  - Go Module
```

