### PR TITLE
RSS link

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -67,6 +67,7 @@ titleCase = true # Capitalized title.
 viewer = true # Image Viewer
 
 # backgroundImage = ['/images/bg-light.png', '/images/bg-dark.png']
+# rss = "home" # link the RSS button to homepage all the times.
 
 [codeBlock]
   # maxLines = 8

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -140,6 +140,7 @@ See also [All Configuration Settings](https://gohugo.io/getting-started/configur
 | `contact` | Object | - | [Contact Form]({{< ref "docs/layouts/contact-form" >}})
 | `pinnedPost` | Boolean | `true` | Turn on/off pinned posts.
 | `pinnedPostCount` | Integer | `1` | The number of pinned posts.
+| `rss` | String/Boolean | `true` | Display the RSS button on the social links. Turn it off by `false`, link it to homepage all the times by setting it to `home`.
 
 > Except the Google webmaster tool, the other webmaster tools cannot work with `hugo --minify`, because they cannot recognize the minified meta tag.
 

--- a/exampleSite/content/docs/configuration/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/index.zh-cn.md
@@ -142,6 +142,7 @@ aliases = [
 | `contact` | Object | - | [联系表单]({{< ref "docs/layouts/contact-form" >}})
 | `pinnedPost` | Boolean | `true` | 开启/禁用文章置顶。
 | `pinnedPostCount` | Integer | `1` | 置顶的文章数量。
+| `rss` | String/Boolean | `true` | 在社交链接中显示 RSS 链接。`false` 为不显示，`home` 则总是链接到主页。
 
 > 除了 Google 站长工具外，其他搜索引擎站长工具无法与 `hugo --minify` 同时使用，这是因为它们无法识别优化后的元标签。
 

--- a/exampleSite/content/docs/configuration/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/index.zh-tw.md
@@ -142,6 +142,7 @@ aliases = [
 | `contact` | Object | - | [聯系表單]({{< ref "docs/layouts/contact-form" >}})
 | `pinnedPost` | Boolean | `true` | 開啟/禁用文章置頂。
 | `pinnedPostCount` | Integer | `1` | 置頂的文章數量。
+| `rss` | String/Boolean | `true` | 在社交鏈接中顯示 RSS 鏈接。`false` 為不顯示，`home` 則總是鏈接到主頁。
 
 > 除了 Google 站長工具外，其他搜索引擎站長工具無法與 `hugo --minify` 同時使用，這是因為它們無法識別優化後的元標簽。
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="footer mt-auto py-3 text-center container{{ if .Site.Params.fullWidth }}-fluid{{ end }}">
   {{- partial "hooks/footer-begin" . -}}
-  {{- partialCached "footer/main" . -}}
+  {{- partial "footer/main" . -}}
   {{- partial "hooks/footer-end" . -}}
 </footer>

--- a/layouts/partials/footer/main.html
+++ b/layouts/partials/footer/main.html
@@ -1,4 +1,4 @@
-{{- partial "footer/menu" . -}}
+{{- partialCached "footer/menu" . -}}
 {{- partial "footer/social-links" . -}}
-{{- partial "footer/copyright" . -}}
-{{- partial "footer/powered-by" . -}}
+{{- partialCached "footer/copyright" . -}}
+{{- partialCached "footer/powered-by" . -}}

--- a/layouts/partials/footer/social-links.html
+++ b/layouts/partials/footer/social-links.html
@@ -1,1 +1,1 @@
-{{- partial "helpers/social-links" (dict "links" .Site.Social "size" "fa-2x" "class" "mb-2" "OutputFormats" $.OutputFormats "home" (.GetPage "/")) -}}
+{{- partial "helpers/social-links" (dict "links" .Site.Social "size" "fa-2x" "class" "mb-2" "OutputFormats" $.OutputFormats "home" (.GetPage "/") "params" .Site.Params) -}}

--- a/layouts/partials/footer/social-links.html
+++ b/layouts/partials/footer/social-links.html
@@ -1,1 +1,1 @@
-{{- partial "helpers/social-links" (dict "links" .Site.Social "size" "fa-2x" "class" "mb-2" "OutputFormats" $.OutputFormats) -}}
+{{- partial "helpers/social-links" (dict "links" .Site.Social "size" "fa-2x" "class" "mb-2" "OutputFormats" $.OutputFormats "home" (.GetPage "/")) -}}

--- a/layouts/partials/helpers/social-links.html
+++ b/layouts/partials/helpers/social-links.html
@@ -49,9 +49,15 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
+  {{- $rss := false -}}
   {{- with .OutputFormats.Get "rss" -}}
-    <a class="nav-link social-link" target="_blank" href="{{ .Permalink }}" title="RSS" rel="noopener noreferrer">
-      <i class="fas fa-fw{{ with $size }} {{ . }}{{ end }} fa-rss"></i>
-    </a>
+    {{- $rss = . -}}
+  {{- else -}}
+    {{- $rss = .home.OutputFormats.Get "rss" -}}
+  {{- end -}}
+  {{- with $rss -}}
+  <a class="nav-link social-link" target="_blank" href="{{ .Permalink }}" title="RSS" rel="noopener noreferrer">
+    <i class="fas fa-fw{{ with $size }} {{ . }}{{ end }} fa-rss"></i>
+  </a>
   {{- end -}}
 </nav>

--- a/layouts/partials/helpers/social-links.html
+++ b/layouts/partials/helpers/social-links.html
@@ -49,15 +49,20 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
+{{- if default true .params.rss -}}
   {{- $rss := false -}}
-  {{- with .OutputFormats.Get "rss" -}}
+  {{- with .home.OutputFormats.Get "rss" -}}
     {{- $rss = . -}}
-  {{- else -}}
-    {{- $rss = .home.OutputFormats.Get "rss" -}}
+  {{- end -}}
+  {{- if ne .params.rss "home" -}}
+    {{- with .OutputFormats.Get "rss" -}}
+      {{- $rss = . -}}
+    {{- end -}}
   {{- end -}}
   {{- with $rss -}}
   <a class="nav-link social-link" target="_blank" href="{{ .Permalink }}" title="RSS" rel="noopener noreferrer">
     <i class="fas fa-fw{{ with $size }} {{ . }}{{ end }} fa-rss"></i>
   </a>
   {{- end -}}
+{{- end -}}
 </nav>

--- a/layouts/partials/sidebar/main.html
+++ b/layouts/partials/sidebar/main.html
@@ -1,4 +1,4 @@
-{{- partialCached "sidebar/profile" . -}}
+{{- partial "sidebar/profile" . -}}
 {{- partial "post/toc" . -}}
 {{- partialCached "sidebar/featured-posts" . .Section -}}
 {{- partialCached "sidebar/recent-posts" . .Section -}}

--- a/layouts/partials/sidebar/profile/meta.html
+++ b/layouts/partials/sidebar/profile/meta.html
@@ -20,6 +20,6 @@
 <div class="profile-contact"><i class="fas fa-fw fa-question-circle"></i><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></div>
 {{- end -}}
 {{- with .social -}}
-{{- partial "helpers/social-links" (dict "links" . "size" "fa-2x" "OutputFormats" $.OutputFormats "home" ($.GetPage "/")) -}}
+{{- partial "helpers/social-links" (dict "links" . "size" "fa-2x" "OutputFormats" $.OutputFormats "home" ($.GetPage "/") "params" $.Site.Params) -}}
 {{- end -}}
 {{- end -}}

--- a/layouts/partials/sidebar/profile/meta.html
+++ b/layouts/partials/sidebar/profile/meta.html
@@ -20,6 +20,6 @@
 <div class="profile-contact"><i class="fas fa-fw fa-question-circle"></i><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></div>
 {{- end -}}
 {{- with .social -}}
-{{- partial "helpers/social-links" (dict "links" . "size" "fa-2x" "OutputFormats" $.OutputFormats) -}}
+{{- partial "helpers/social-links" (dict "links" . "size" "fa-2x" "OutputFormats" $.OutputFormats "home" ($.GetPage "/")) -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
There are three options of RSS links:

- `true`(default): depends on the pages. It links to the page's RSS, such as `/categories/index.xml`,  `/tags/index.xml`, fallback to the homepage RSS if necessary. 
- `false`: hide the RSS button.
- `home`: link it to homepage all the times.


```toml
// config/_default/params.toml
# rss = true
```