### PR TITLE
Performance: make FAQ CSS purgeable

### DIFF
--- a/assets/main/scss/index.scss
+++ b/assets/main/scss/index.scss
@@ -40,7 +40,7 @@
 @import 'top-app-bar';
 @import 'loading-bar';
 @import 'snackbar';
-@import 'faq';
 @import 'docs';
 @import 'custom';
 /*! purgecss end ignore */
+@import 'faq';


### PR DESCRIPTION
This PR is useful for users who don't use the FAQ layout at all, the CSS bundle size will be reduces by about `5.5kB`.