### PR TITLE
feat(code-block): display the title attribute

### DIFF
--- a/assets/js/code/code-block.ts
+++ b/assets/js/code/code-block.ts
@@ -42,6 +42,7 @@ class CodeBlock {
     this.wrapper.appendChild(this.element);
 
     this.appendLang();
+    this.appendTitle();
     this.appendPanel();
   }
 
@@ -49,8 +50,18 @@ class CodeBlock {
     const lang = this.code.getAttribute('data-lang');
     if (lang) {
       const element = document.createElement('div');
-      element.className = 'lang';
+      element.className = 'lang position-absolute top-0 end-0 text-white fst-italic text-uppercase opacity-50 fs-xs pe-3 pt-1';
       element.innerHTML = lang;
+      this.wrapper.appendChild(element);
+    }
+  }
+
+  appendTitle() {
+    const title = this.element.getAttribute('title');
+    if (title) {
+      const element = document.createElement('div');
+      element.className = 'title position-absolute bottom-0 end-0 text-white fst-italic opacity-50 pe-3 pb-1';
+      element.innerHTML = title;
       this.wrapper.appendChild(element);
     }
   }

--- a/assets/main/scss/_code.scss
+++ b/assets/main/scss/_code.scss
@@ -2,18 +2,6 @@
   position: relative;
   margin: 1.5rem auto 1rem;
 
-  .lang {
-    color: white;
-    position: absolute;
-    right: 0;
-    top: 0;
-    font-size: 0.75rem;
-    font-style: italic;
-    opacity: 0.5;
-    padding: 0.25rem 0.75rem 0.25rem 0.5rem;
-    text-transform: uppercase;
-  }
-
   .panel {
     position: absolute;
     top: -1.5rem;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,10 +5,14 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
       return els.tags.concat(els.classes, els.ids);
   },
   safelist: [
+    'bottom-0',
     'col-lg-10',
-    'fs-lg', 'fs-sm', 'fs-xl', 'fs-xs',
+    'end-0',
+    'fs-lg', 'fs-sm', 'fs-xl', 'fs-xs', 'fst-italic',
+    'opacity-50',
+    'pb-1', 'pe-3', 'pt-1', 'position-absolute',
     'show',
-    'text-pre-wrap',
+    'text-pre-wrap', 'text-uppercase', 'text-white', 'top-0',
   ]
 });
 


### PR DESCRIPTION
Now, the code block will display the `title` attribute on the bottom.

<pre>
```toml {title="config/_default/params.toml"}
mainSections = ["blog", "posts", "docs", "notes"]
```
</pre>

![image](https://user-images.githubusercontent.com/17720932/158994986-b2ed4b3d-f4a7-44fc-bb81-11dc8ba789f0.png)
