### PR TITLE
feat(image-viewer): add the data-viewer-invisible attribute for image tag

### DIFF
--- a/assets/viewer/js/index.ts
+++ b/assets/viewer/js/index.ts
@@ -3,16 +3,12 @@ import options from './options';
 
 class Gallery {
     gallery: Viewer;
-    
-    excludeClassNames = [
-      'profile-avatar',
-    ];
 
     constructor() {
         const self = this;
         const defaultOptions: Viewer.Options = {
             filter(img: HTMLImageElement) {
-                return self.isImageValid(img);
+                return self.validate(img);
             },
             url(img: HTMLImageElement) {
               return img.hasAttribute('data-src') ? img.getAttribute('data-src') : img.src;
@@ -25,7 +21,7 @@ class Gallery {
     run() {
         const self = this;
         document.querySelectorAll('img').forEach(function (img) {
-            if (img.parentElement.tagName !== 'A' && self.isImageValid(img)) {
+            if (img.parentElement.tagName !== 'A' && self.validate(img)) {
               img.addEventListener('click', function () {
                 self.gallery.show();
               });
@@ -33,8 +29,8 @@ class Gallery {
         });
     }
 
-    isImageValid(img) {
-      return this.excludeClassNames.filter(name => img.classList.contains(name)).length == 0;
+    validate(img) {
+      return !img.hasAttribute('data-viewer-invisible');
     }
 }
 

--- a/layouts/partials/helpers/image.html
+++ b/layouts/partials/helpers/image.html
@@ -63,6 +63,6 @@
   {{- $link = $img.Permalink -}}
 {{- end -}}
 
-<img class="{{ $className }}" alt="{{ .alt }}" src="{{ $link }}" loading="lazy"
+<img class="{{ $className }}" alt="{{ .alt }}" src="{{ $link }}" loading="lazy"{{ with .attributes }} {{ . }}{{ end }}
   {{ with $img }} width="{{ .Width }}" height="{{ .Height }}"{{ end }}
   {{ if and (not (and $pageResource $resizable)) (or $width $height) }}style="{{ with $width }}width: {{ . }}; {{ end }}{{ with $height }}height: {{ . }}{{ end }}"{{ end }} />

--- a/layouts/partials/post/reward.html
+++ b/layouts/partials/post/reward.html
@@ -24,7 +24,7 @@
           {{- $index = 0 -}}
           {{- range $key, $value := $reward -}}
           <div class="tab-pane fade post-reward-content show{{ if eq $index 0 }} active{{ end }}" id="reward-{{ $key }}" role="tabpanel" aria-labelledby="reward-{{ $key }}-tab">
-            <img class="img-fluid post-reward-img" src="{{ absURL $value }}" loading="lazy" />
+            <img class="img-fluid post-reward-img" src="{{ absURL $value }}" loading="lazy" data-viewer-invisible />
           </div>
           {{- $index = add $index 1 -}}
           {{- end -}}

--- a/layouts/partials/sidebar/profile/avatar.html
+++ b/layouts/partials/sidebar/profile/avatar.html
@@ -1,3 +1,4 @@
 {{- with .Site.Author -}}
-{{- partial "helpers/image" (dict "filename" (default "images/profile.webp" .avatar) "class" "profile-avatar rounded-circle" "alt" .name "resources" $.Resources) -}}
+{{- $attributes := printf "data-viewer-invisible" | safeHTMLAttr -}}
+{{- partial "helpers/image" (dict "filename" (default "images/profile.webp" .avatar) "class" "profile-avatar rounded-circle" "alt" .name "resources" $.Resources "attributes" $attributes) -}}
 {{- end -}}


### PR DESCRIPTION
Images with the `data-viewer-invisible` attribute will be filtered by the image viewer. It allows users excluding custom images from the image viewer.

```html
<img data-viewer-invisible src="/images/foo.png" />
```

