### PR TITLE
fix: Add missing 'all' word to i18n

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -7,6 +7,9 @@ other = "تعذر الوصول إلى الصفحة المطلوبة."
 [about_me]
 other = "عنّي"
 
+[all]
+other = "الكل"
+
 [alipay]
 other = "علي باي"
 

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -7,11 +7,11 @@ other = "تعذر الوصول إلى الصفحة المطلوبة."
 [about_me]
 other = "عنّي"
 
-[all]
-other = "الكل"
-
 [alipay]
 other = "علي باي"
+
+[all]
+other = "الكل"
 
 [archives]
 other = "الأرشيف"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -7,11 +7,11 @@ other = "We can't seems to find the page you're looking for."
 [about_me]
 other = "About Me"
 
-[all]
-other = "All"
-
 [alipay]
 other = "Alipay"
+
+[all]
+other = "All"
 
 [archives]
 other = "Archives"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -7,6 +7,9 @@ other = "We can't seems to find the page you're looking for."
 [about_me]
 other = "About Me"
 
+[all]
+other = "All"
+
 [alipay]
 other = "Alipay"
 

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -10,6 +10,9 @@ other = "关于我"
 [alipay]
 other = "支付宝"
 
+[all]
+other = "全部"
+
 [archives]
 other = "归档"
 

--- a/i18n/zh-hk.toml
+++ b/i18n/zh-hk.toml
@@ -10,6 +10,9 @@ other = "關於我"
 [alipay]
 other = "支付寶"
 
+[all]
+other = "全部"
+
 [archives]
 other = "歸檔"
 

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -10,6 +10,9 @@ other = "關於我"
 [alipay]
 other = "支付寶"
 
+[all]
+other = "全部"
+
 [archives]
 other = "歸檔"
 

--- a/layouts/partials/sidebar/taxonomies.html
+++ b/layouts/partials/sidebar/taxonomies.html
@@ -27,8 +27,8 @@
           {{- end -}}
         {{- end -}}
         {{- if gt (len $value) $taxonomyCount -}}
-        <a href="{{ absLangURL (urlize $key) }}" class="badge rounded post-taxonomy" title="ALL">
-          ALL
+        <a href="{{ absLangURL (urlize $key) }}" class="badge rounded post-taxonomy" title='{{ i18n "all" | upper }}'>
+          {{ i18n "all" | upper }}
           <span class="badge badge-sm text-white bg-accent ms-1">{{ len $value }}</span>
         </a>
         {{- end -}}


### PR DESCRIPTION
Taxonomies "all" button link was missing from internationalization. 