### PR TITLE
fix(docs-repo): use the correct contentDir when custom one is set

### DIFF
--- a/layouts/partials/docs/repo.html
+++ b/layouts/partials/docs/repo.html
@@ -3,6 +3,7 @@
 {{- $branch := default "master" .branch -}}
 {{- $dateFormat := default "02/01/2006, 15:04:05 PM" .dateFormat -}}
 {{- $subPath := default "" .subPath -}}
+{{- $contentDir := default "content" $.Site.Language.ContentDir -}}
 {{- if $subPath -}}{{ $subPath = printf "/%s" $subPath }}{{- end -}}
 <div class="docs-repo row card component">
     <div class="card-header">
@@ -11,7 +12,7 @@
     <div class="card-body">
         <ul class="list-unstyled">
             {{- if $.File -}}
-            {{- $filePath := printf "%s%s/content/%s" $branch $subPath $.File.Path -}}
+            {{- $filePath := printf "%s%s/%s/%s" $branch $subPath $contentDir $.File.Path -}}
             <li class="mb-1">
                 <a href="{{ printf "%s/blob/%s" $url $filePath }}" target="_blank" rel="noopener noreferrer">
                     <i class="fas fa-fw fa-file-archive"></i> {{ i18n "repo_action_view" }}


### PR DESCRIPTION
Fixes https://github.com/razonyang/hugo-theme-bootstrap/issues/475
