### PR TITLE
Feature: add parameter `tocPosition`.

### DIFF
--- a/assets/main/scss/post/index.scss
+++ b/assets/main/scss/post/index.scss
@@ -190,6 +190,12 @@
   scroll-margin-top: 84px;
 }
 
+.post {
+  #TableOfContents {
+    color: var(--#{$variable-prefix}primary-text-on-surface);
+  }
+}
+
 /*!rtl:raw:
 .post-prev-icon, .post-next-icon {
   transform: scaleX(-1);

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -29,6 +29,7 @@ googleAdsense = ""
 
 # math = true # Enable math globally.
 # toc = false # Disable TOC globally.
+# tocPosition = "content"
 # breadcrumb = false # Disable breadcrumb
 # diagram = true
 # socialShare = false # disable social network sharing

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -159,6 +159,7 @@ See also [All Configuration Settings](https://gohugo.io/getting-started/configur
 | `keywords` | Array | - | Page keywords.
 | `comment` | Boolean | `true` | Whether to enable comments. It won't work if `comment` has been disabled globally.
 | `toc` | Boolean | `true` | Whether to enable TOC. It won't work if `toc` has been disabled globally.
+| `tocPosition` | String | `sidebar` | Available values: `sidebar` and `content`.
 | `math` | Boolean | `false` | Whether to enable math.
 | `diagram` | Boolean | `false` | Whether to enable diagram.
 | `reward` | Boolean | `true` | Whether to enable reward.

--- a/exampleSite/content/docs/configuration/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/index.zh-cn.md
@@ -62,6 +62,7 @@ aliases = [
 | `backgroundImage` | Array | `[]` | 背景图，如：`['/images/bg.png']`, `['/images/bg-light.png', '/images/bg-dark.png']`。
 | `comment` | Boolean | `true` | 是否开启评论
 | `toc` | Boolean | `true` | 是否开启目录
+| `tocPosition` | String | `sidebar` | 可选值：`sidebar` 和 `content`。
 | `tocWordCount` | Integer | `280` | 仅当文章的字数超过此值时，才会显示目录。
 | `breadcrumb` | Boolean | `true` | 是否开启面包屑导航
 | `dateFormat` | String | `Jan 2, 2006` | 日期格式。 查阅 [Hugo Date and Time Templating Reference](https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference) 以获取详细信息。

--- a/exampleSite/content/docs/configuration/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/index.zh-tw.md
@@ -62,6 +62,7 @@ aliases = [
 | `backgroundImage` | Array | `[]` | 背景圖，如：`['/images/bg.png']`, `['/images/bg-light.png', '/images/bg-dark.png']`。
 | `comment` | Boolean | `true` | 是否開啟評論
 | `toc` | Boolean | `true` | 是否開啟目錄
+| `tocPosition` | String | `sidebar` | 可選值：`sidebar` 和 `content`。
 | `tocWordCount` | Integer | `280` | 僅當文章的字數超過此值時，才會顯示目錄。
 | `breadcrumb` | Boolean | `true` | 是否開啟面包屑導航
 | `dateFormat` | String | `Jan 2, 2006` | 日期格式。 查閱 [Hugo Date and Time Templating Reference](https://gohugo.io/functions/format/#hugo-date-and-time-templating-reference) 以獲取詳細信息。

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -1,3 +1,3 @@
 {{- if .IsPage -}}
-{{ partial "post/toc" . }}
+{{ partial "sidebar/toc" . }}
 {{- end -}}

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -7,6 +7,9 @@
     {{- partial "post/meta" . -}}
     {{- partial "post/featured-image" . -}}
     {{- partial "hooks/content-begin" . -}}
+    {{- if eq "content" .Site.Params.tocPosition -}}
+      {{- partial "post/toc" . -}}
+    {{- end -}}
     {{- partial "post/share" . -}}
     <div class="post-content mb-3">
       {{- .Content -}}

--- a/layouts/partials/sidebar/main.html
+++ b/layouts/partials/sidebar/main.html
@@ -1,5 +1,7 @@
 {{- partial "sidebar/profile" . -}}
-{{- partial "post/toc" . -}}
+{{- if ne "content" .Site.Params.tocPosition -}}
+{{- partial "sidebar/toc" . -}}
+{{- end -}}
 {{- partialCached "sidebar/featured-posts" . .Section -}}
 {{- partialCached "sidebar/recent-posts" . .Section -}}
 {{- partialCached "sidebar/taxonomies" . -}}

--- a/layouts/partials/sidebar/toc.html
+++ b/layouts/partials/sidebar/toc.html
@@ -2,11 +2,12 @@
 {{- $toc := .TableOfContents -}}
 {{- $valid := and $toc (and (ne $toc "<nav id=\"TableOfContents\"></nav>") (gt .WordCount .Site.Params.tocWordCount)) -}}
 {{- if and $enable $valid -}}
-<div id="postTOC">
-  <h2 class="mb-3">
-    {{- i18n "table_of_contents" -}}
-    <a class="anchor ms-1" href="#postTOC"><i class="fas fa-link"></i></a>
-  </h2>
-  {{ $toc }}
+<div class="post-toc row mb-4 card component" id="postTOC">
+  <div class="card-header">
+    <h2 class="card-title">{{ i18n "table_of_contents" }}</h2>
+  </div>
+  <div class="card-body">
+    {{ $toc }}
+  </div>
 </div>
 {{- end -}}


### PR DESCRIPTION
Fixed #382.

This PR adds a new parameter called `tocPosition`. You can move the TOC inside the post content by setting `tocPosition = "content"`. It only affects on `posts`'s layout.
