### PR TITLE
feat: numberify headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ There is also a [list of websites that use this theme](https://github.com/razony
 - [Twitter Cards](https://gohugo.io/templates/internal/#configure-twitter-cards) and [Open Graph](https://gohugo.io/templates/internal/#configure-open-graph).
 - [Creative Commons License](https://creativecommons.org/licenses/).
 - [Contact Form](https://hbs.razonyang.com/en/docs/layouts/contact-form).
+- Numberify Headings Automatically.

--- a/assets/main/scss/_config.scss
+++ b/assets/main/scss/_config.scss
@@ -26,3 +26,7 @@ $validPalettes: true;
         {{- end -}}
     {{- end -}}
 {{- end -}}
+
+$numberifyHeadings: {{ default false $params.post.numberifyHeadings }};
+$numberifyHeadingsSeparator: '{{ default "" $params.post.numberifyHeadingsSeparator }}' + "\0000a0";
+$numberifyHeadingsEndLevel: {{ default 6 $params.post.numberifyHeadingsEndLevel }};

--- a/assets/main/scss/post/index.scss
+++ b/assets/main/scss/post/index.scss
@@ -54,6 +54,35 @@
   }
 }
 
+@if $numberifyHeadings {
+  .post-content {
+    counter-reset: h2Counter;
+    @for $heading from 2 through $numberifyHeadingsEndLevel {
+      h#{$heading} {
+        @if $heading < $numberifyHeadingsEndLevel {
+          counter-reset: h#{$heading+1}Counter;
+        }
+
+        &::before {
+          display: inline;
+          counter-increment: h#{$heading}Counter;
+          @if $heading == 2 {
+            content: counter(h2Counter) $numberifyHeadingsSeparator;
+          } @else if $heading == 3 {
+            content: counter(h2Counter) '.' counter(h3Counter) $numberifyHeadingsSeparator;
+          } @else if $heading == 4 {
+            content: counter(h2Counter) '.' counter(h3Counter) '.' counter(h4Counter) $numberifyHeadingsSeparator;
+          } @else if $heading == 5 {
+            content: counter(h2Counter) '.' counter(h3Counter) '.' counter(h4Counter) '.' counter(h5Counter) $numberifyHeadingsSeparator;
+          } @else if $heading == 6 {
+            content: counter(h2Counter) '.' counter(h3Counter) '.' counter(h4Counter) '.' counter(h5Counter) '.' counter(h6Counter) $numberifyHeadingsSeparator;
+          }
+        }
+      }
+    }
+  }
+}
+
 .post-meta,
 .post-summary,
 .post-content,

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -84,6 +84,9 @@ viewer = true # Image Viewer
   # copyright = false # Whether to display copyright section on each post.
   # plainifyExcerpt = false # Format excerpt in HTML if false.
   featuredImage = true # Show the featured image above the content.
+  numberifyHeadings = true # Count headings automatically.
+  # numberifyHeadingsEndLevel = 4 # The depth of headings to count. Default to 6.
+  # numberifyHeadingsSeparator = "." # The separator between of number and headings.
 
 [archive]
   paginate = 20 # Archive pagination. Default to 100.

--- a/exampleSite/content/docs/configuration/index.md
+++ b/exampleSite/content/docs/configuration/index.md
@@ -134,6 +134,9 @@ See also [All Configuration Settings](https://gohugo.io/getting-started/configur
 | `post.copyright` | Boolean | `true` | Whether to display copyright section on each post.
 | `post.plainifyExcerpt` | Boolean | `true` | Format excerpt in HTML if `false`.
 | `post.featuredImage` | Boolean | `false` | Show the featured image above the content.
+| `post.numberifyHeadings` | Boolean | `false` | Count headings automatically.
+| `post.numberifyHeadingsEndLevel` | Number | `6` | The depth of headings to count.
+| `post.numberifyHeadingsSeparator` | String | - | The separator between of number and headings.
 | `viewer` | Boolean | true | [Image Viewer]({{< ref "docs/image-viewer" >}})
 | `pwa` | Object | - | [Progressive Web Apps]({{< ref "/docs/pwa" >}})
 | **Sidebar**

--- a/exampleSite/content/docs/configuration/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/index.zh-cn.md
@@ -138,6 +138,9 @@ aliases = [
 | `post.copyright` | Boolean | `true` | 是否在每个帖子上显示版权部分
 | `post.plainifyExcerpt` | Boolean | `true` | `false` 则格式化摘要为 HTML。
 | `post.featuredImage` | Boolean | `false` | 于内容上方显示 Featured 图片。
+| `post.numberifyHeadings` | Boolean | `false` | 是否自动对标题进行编号。
+| `post.numberifyHeadingsEndLevel` | Number | `6` | 自动编号的深度。
+| `post.numberifyHeadingsSeparator` | String | - | 编号和标题之间的分隔符。
 | `viewer` | Boolean | true | [图片查看器]({{< ref "docs/image-viewer" >}})
 | `pwa` | Object | - | [渐进式 web 应用]({{< ref "/docs/pwa" >}})
 | **Sidebar**

--- a/exampleSite/content/docs/configuration/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/index.zh-tw.md
@@ -138,6 +138,9 @@ aliases = [
 | `post.copyright` | Boolean | `true` | 是否在每個帖子上顯示版權部分
 | `post.plainifyExcerpt` | Boolean | `true` | `false` 則格式化摘要為 HTML。
 | `post.featuredImage` | Boolean | `false` | 於內容上方顯示 Featured 圖片。
+| `post.numberifyHeadings` | Boolean | `false` | 是否自動對標題進行編號。
+| `post.numberifyHeadingsEndLevel` | Number | `6` | 自動編號的深度。
+| `post.numberifyHeadingsSeparator` | String | - | 編號和標題之間的分隔符。
 | `viewer` | Boolean | true | [圖片查看器]({{< ref "docs/image-viewer" >}})
 | `pwa` | Object | - | [漸進式 web 應用]({{< ref "/docs/pwa" >}})
 | **Sidebar**


### PR DESCRIPTION
Added the `post.numberifyHeadings` parameter.

```toml
[post]
  numberifyHeadings = true # Count headings automatically.
  # numberifyHeadingsEndLevel = 4 # The depth of headings to count. Default to 6.
  # numberifyHeadingsSeparator = "." # The separator between of number and headings.
```


Relative to #501.
