### PR TITLE
feat: add the taxonomies toggle widget

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -74,7 +74,11 @@ viewer = true # Image Viewer
 
 [sidebar]
   # fixed = true
-  # archive = false
+  # archives = true # Enable archives widget
+  # taxonomiesToggle = false # Disable taxonomy toggle
+  # categories = true # Enable categories widget
+  # tags = true # Enable tags widget
+  # series = true # Enable series widget
 
 [codeBlock]
   # maxLines = 8

--- a/exampleSite/content/docs/configuration/site-params/index.md
+++ b/exampleSite/content/docs/configuration/site-params/index.md
@@ -125,7 +125,11 @@ The site parameters are located in `config/_default/params.toml` by default.
 | **Sidebar**
 | `sidebar` | Object | - |
 | `sidebar.fixed` | Boolean | `false` | Fix default sidebar.
-| `sidebar.archive` | Boolean | `true` | Show the archive widget on the sidebar.
+| `sidebar.taxonomiesToggle` | Boolean | `true` | Show the taxonomies toggle widget on the sidebar.
+| `sidebar.series` | Boolean | `false` | Show the series widget on the sidebar.
+| `sidebar.categories` | Boolean | `false` | Show the categories widget on the sidebar.
+| `sidebar.tags` | Boolean | `false` | Show the tags widget on the sidebar.
+| `sidebar.archives` | Boolean | `false` | Show the archive widget on the sidebar.
 | **Meta Tag**
 | `metaRobots` | String | - | Empty means that turn it off.
 | `contact` | Object | - | [Contact Form]({{< ref "docs/layouts/contact-form" >}})

--- a/exampleSite/content/docs/configuration/site-params/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-cn.md
@@ -128,7 +128,11 @@ weight = 980
 | **Sidebar**
 | `sidebar` | Object | - |
 | `sidebar.fixed` | Boolean | `false` | 固定默认侧边栏。
-| `sidebar.archive` | Boolean | `true` | 于侧边栏显示归档挂件。
+| `sidebar.taxonomiesToggle` | Boolean | `true` | Show the taxonomies toggle widget on the sidebar.
+| `sidebar.series` | Boolean | `false` | Show the series widget on the sidebar.
+| `sidebar.categories` | Boolean | `false` | Show the categories widget on the sidebar.
+| `sidebar.tags` | Boolean | `false` | Show the tags widget on the sidebar.
+| `sidebar.archives` | Boolean | `false` | Show the archive widget on the sidebar.
 | **Meta Tag**
 | `metaRobots` | String | - | 空字符串表示禁用。
 | `contact` | Object | - | [联系表单]({{< ref "docs/layouts/contact-form" >}})

--- a/exampleSite/content/docs/configuration/site-params/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-tw.md
@@ -128,7 +128,11 @@ weight = 980
 | **Sidebar**
 | `sidebar` | Object | - |
 | `sidebar.fixed` | Boolean | `false` | 固定默認側邊欄。
-| `sidebar.archive` | Boolean | `true` | 於側邊欄顯示歸檔掛件。
+| `sidebar.taxonomiesToggle` | Boolean | `true` | Show the taxonomies toggle widget on the sidebar.
+| `sidebar.series` | Boolean | `false` | Show the series widget on the sidebar.
+| `sidebar.categories` | Boolean | `false` | Show the categories widget on the sidebar.
+| `sidebar.tags` | Boolean | `false` | Show the tags widget on the sidebar.
+| `sidebar.archives` | Boolean | `false` | Show the archive widget on the sidebar.
 | **Meta Tag**
 | `metaRobots` | String | - | 空字符串表示禁用。
 | `contact` | Object | - | [聯系表單]({{< ref "docs/layouts/contact-form" >}})

--- a/layouts/partials/sidebar/archive-items.html
+++ b/layouts/partials/sidebar/archive-items.html
@@ -1,0 +1,8 @@
+{{- $basePath := strings.TrimSuffix "/" (default "/archives" .Site.Params.archive.basePath) -}}
+{{- $basePath = printf "/%s/" (strings.TrimPrefix "/" $basePath)  -}}
+{{ range (where $.Site.RegularPages "Type" "in" $.Site.Params.mainSections).GroupByDate "2006" }}
+    {{- $yearPage := $.GetPage (printf "%s%s" $basePath .Key) -}}
+    <a href="{{ with $yearPage }}{{ .Permalink }}{{ end }}" class="btn btn-sm btn-secondary post-taxonomy me-2 mb-2" title="{{ .Key }}">
+    {{ .Key }} <span class="badge badge-sm text-secondary bg-white ms-1">{{ len .Pages}}</span>
+    </a>
+{{ end }}

--- a/layouts/partials/sidebar/archive.html
+++ b/layouts/partials/sidebar/archive.html
@@ -1,4 +1,4 @@
-{{- if default true $.Site.Params.sidebar.archive -}}
+{{- if default false $.Site.Params.sidebar.archives -}}
 {{- $basePath := strings.TrimSuffix "/" (default "/archives" .Site.Params.archive.basePath) -}}
 {{- $basePath = printf "/%s/" (strings.TrimPrefix "/" $basePath)  -}}
 {{- $archivePage := $.GetPage $basePath -}}
@@ -13,12 +13,7 @@
       </h2>
     </div>
     <div class="card-body">
-      {{ range (where $.Site.RegularPages "Type" "in" $.Site.Params.mainSections).GroupByDate "2006" }}
-        {{- $yearPage := $.GetPage (printf "%s%s" $basePath .Key) -}}
-        <a href="{{ with $yearPage }}{{ .Permalink }}{{ end }}" class="btn btn-sm btn-secondary post-taxonomy me-2 mb-2" title="{{ .Key }}">
-          {{ .Key }} <span class="badge badge-sm text-secondary bg-white ms-1">{{ len .Pages}}</span>
-        </a>
-      {{ end }}
+      {{- partial "sidebar/archive-items" . -}}
     </div>
 </section>
 {{- end -}}

--- a/layouts/partials/sidebar/main.html
+++ b/layouts/partials/sidebar/main.html
@@ -1,4 +1,5 @@
 {{- partial "sidebar/profile" . -}}
+{{- partialCached "sidebar/taxonomies-toggle" . -}}
 {{- if ne "content" .Site.Params.tocPosition -}}
 {{- partial "sidebar/toc" . -}}
 {{- end -}}

--- a/layouts/partials/sidebar/taxonomies-toggle.html
+++ b/layouts/partials/sidebar/taxonomies-toggle.html
@@ -1,0 +1,77 @@
+
+{{- if default true .Site.Params.sidebar.taxonomiesToggle -}}
+<section class="taxonomies row card component">
+    <div class="card-body">
+        <ul class="nav nav-tabs" id="myTab" role="tablist">
+            {{- $counter := 0 -}}
+            {{- range $expected := $.Site.Params.sidebarTaxonomies -}}
+            {{- range $key, $value := $.Site.Taxonomies -}}
+              {{- if eq $key $expected -}}
+              {{- $countParams := dict "categories" "categoryCount" "tags" "tagCount" "series" "seriesCount" -}}
+              {{- $param := default "" (index $countParams $key) -}}
+              {{- $taxonomyCount := default 10 ($.Site.Param $param) -}}
+              {{- if $taxonomyCount -}}
+                {{- with $value.ByCount -}}
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link{{ if eq $counter 0 }} active{{ end }}" id="taxonomy{{ $key | title }}Tab" data-bs-toggle="tab" data-bs-target="#taxonomy{{ $key | title }}" 
+                        type="button" role="tab" aria-controls="{{ T $key }}" aria-selected="true">
+                        {{ T $key }}
+                    </button>
+                </li>
+                {{- end -}}
+              {{- end -}}
+              {{- $counter = add $counter 1 -}}
+              {{- end -}}
+            {{- end -}}
+            {{- end -}}
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="taxonomyArchivesTab" data-bs-toggle="tab" data-bs-target="#taxonomyArchive" 
+                    type="button" role="tab" aria-controls="taxonomyArchives" aria-selected="true">
+                    {{ T "archives" }}
+                </button>
+            </li>
+        </ul>
+          
+        <div class="tab-content mt-3">
+            {{- $counter := 0 -}}
+            {{- range $expected := $.Site.Params.sidebarTaxonomies -}}
+            {{- range $key, $value := $.Site.Taxonomies -}}
+            {{- if eq $key $expected -}}
+            {{- $countParams := dict "categories" "categoryCount" "tags" "tagCount" "series" "seriesCount" -}}
+            {{- $param := default "" (index $countParams $key) -}}
+            {{- $taxonomyCount := default 10 ($.Site.Param $param) -}}
+            {{- if $taxonomyCount -}}
+                {{- with $value.ByCount -}}
+                <div class="tab-pane{{ if eq $counter 0 }} active{{ end }}" id="taxonomy{{ $key | title }}" role="tabpanel" aria-labelledby="taxonomy{{ $key | title }}Tab" tabindex="0">
+                    {{- $count := 0 -}}
+                    {{- range . -}}
+                    {{- if and (lt $count $taxonomyCount) (ne .Name "") -}}
+                    <a href="{{ .Page.Permalink }}" class="btn btn-sm btn-secondary post-taxonomy me-2 mb-2" title="{{ .Page.Title }}">
+                        {{ .Page.Title }}
+                        {{- if $.Site.Params.countTaxonomyPosts -}}
+                        <span class="badge badge-sm text-secondary bg-white ms-1">{{ .Count }}</span>
+                        {{- end -}}
+                    </a>
+                    {{- $count = add $count 1 }}
+                    {{- end -}}
+                    {{- end -}}
+                    {{- if gt (len $value) $taxonomyCount -}}
+                    <a href="{{ absLangURL (urlize $key) }}" class="btn btn-sm btn-secondary post-taxonomy me-2 mb-2" title='{{ i18n "all" | upper }}'>
+                    {{ i18n "all" | upper }}
+                    <span class="badge badge-sm text-secondary bg-white ms-1">{{ len $value }}</span>
+                    </a>
+                    {{- end -}}
+                </div>
+                {{- $counter = add $counter 1 -}}
+                {{- end -}}
+            {{- end -}}
+            {{- end -}}
+            {{- end -}}
+            {{- end -}}
+            <div class="tab-pane" id="taxonomyArchive" role="tabpanel" aria-labelledby="taxonomyArchiveTab" tabindex="0">
+                {{- partial "sidebar/archive-items" . -}}
+            </div>
+        </div>
+    </div>
+</section>
+{{- end -}}

--- a/layouts/partials/sidebar/taxonomies.html
+++ b/layouts/partials/sidebar/taxonomies.html
@@ -1,6 +1,7 @@
 {{- range $expected := $.Site.Params.sidebarTaxonomies -}}
 {{- range $key, $value := $.Site.Taxonomies -}}
-  {{- if eq $key $expected -}}
+  {{- $enable := default false (index $.Site.Params.sidebar $key) -}}
+  {{- if and $enable (eq $key $expected) -}}
   {{- $countParams := dict "categories" "categoryCount" "tags" "tagCount" "series" "seriesCount" -}}
   {{- $param := default "" (index $countParams $key) -}}
   {{- $taxonomyCount := default 10 ($.Site.Param $param) -}}


### PR DESCRIPTION
Add the taxonomies toggle for saving sidebar space.
Disable previous categories, tags, series and archives widget by default.

![image](https://user-images.githubusercontent.com/17720932/174231490-cd23aea4-b63f-419a-9e3b-be45694a0bd7.png)

If you want to use the previous widgets, just enable them in `params.toml`:

```toml
[sidebar]
  archives = true # Enable archives widget
  taxonomiesToggle = false # Disable taxonomy toggle
  categories = true # Enable categories widget
  tags = true # Enable tags widget
  series = true # Enable series widget
```