### PR TITLE
Add Posts Toggle Widget

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -80,6 +80,9 @@ viewer = true # Image Viewer
   # tags = true # Enable tags widget
   # series = true # Enable series widget
   # authors = true # Enable authors widget
+  # postsToggle = false # Disable posts toggle
+  # featuredPosts = true # Enable featured posts widget
+  # recentPosts = true # Enable featured posts widget
 
 [codeBlock]
   # maxLines = 8

--- a/exampleSite/content/docs/advanced/custom-assets/index.md
+++ b/exampleSite/content/docs/advanced/custom-assets/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Custom Assets"
 date = 2021-11-28T16:00:49+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/advanced/custom-assets/index.zh-cn.md
+++ b/exampleSite/content/docs/advanced/custom-assets/index.zh-cn.md
@@ -1,7 +1,7 @@
 +++
 title = "自定义资源"
 date = 2021-11-28T16:00:53+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/advanced/custom-assets/index.zh-tw.md
+++ b/exampleSite/content/docs/advanced/custom-assets/index.zh-tw.md
@@ -1,7 +1,7 @@
 +++
 title = "自定義資源"
 date = 2021-11-28T16:00:56+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/advanced/hooks/index.md
+++ b/exampleSite/content/docs/advanced/hooks/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Hooks"
 date = 2021-11-27T19:54:29+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/advanced/hooks/index.zh-cn.md
+++ b/exampleSite/content/docs/advanced/hooks/index.zh-cn.md
@@ -1,7 +1,7 @@
 +++
 title = "钩子"
 date = 2021-11-27T21:04:32+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/advanced/hooks/index.zh-tw.md
+++ b/exampleSite/content/docs/advanced/hooks/index.zh-tw.md
@@ -1,7 +1,7 @@
 +++
 title = "鉤子"
 date = 2021-11-27T21:04:35+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/page-params/index.md
+++ b/exampleSite/content/docs/configuration/page-params/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Page Parameters"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/page-params/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/page-params/index.zh-cn.md
@@ -1,7 +1,7 @@
 +++
 title = "页面参数"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/page-params/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/page-params/index.zh-tw.md
@@ -1,7 +1,7 @@
 +++
 title = "頁面參數"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/site-params/index.md
+++ b/exampleSite/content/docs/configuration/site-params/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Site Parameters"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/site-params/index.md
+++ b/exampleSite/content/docs/configuration/site-params/index.md
@@ -136,6 +136,9 @@ The site parameters are located in `config/_default/params.toml` by default.
 | `sidebar.tags` | Boolean | `false` | Show the tags widget on the sidebar.
 | `sidebar.archives` | Boolean | `false` | Show the archive widget on the sidebar.
 | `sidebar.authors` | Boolean | `false` | Show the authors widget on the sidebar.
+| `sidebar.postsToggle` | Boolean | `true` | Show the posts toggle on the sidebar.
+| `sidebar.featuredPosts` | Boolean | `false` | Show the featured posts widget on the sidebar.
+| `sidebar.recentPosts` | Boolean | `false` | Show the recent posts widget on the sidebar.
 | **Meta Tag**
 | `metaRobots` | String | - | Empty means that turn it off.
 | `contact` | Object | - | [Contact Form]({{< ref "docs/layouts/contact" >}})

--- a/exampleSite/content/docs/configuration/site-params/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-cn.md
@@ -1,7 +1,7 @@
 +++
 title = "站点参数"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/site-params/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-cn.md
@@ -139,6 +139,9 @@ authors = ["RazonYang"]
 | `sidebar.tags` | Boolean | `false` | Show the tags widget on the sidebar.
 | `sidebar.archives` | Boolean | `false` | Show the archive widget on the sidebar.
 | `sidebar.authors` | Boolean | `false` | Show the authors widget on the sidebar.
+| `sidebar.postsToggle` | Boolean | `true` | Show the posts toggle on the sidebar.
+| `sidebar.featuredPosts` | Boolean | `false` | Show the featured posts widget on the sidebar.
+| `sidebar.recentPosts` | Boolean | `false` | Show the recent posts widget on the sidebar.
 | **Meta Tag**
 | `metaRobots` | String | - | 空字符串表示禁用。
 | `contact` | Object | - | [联系表单]({{< ref "docs/layouts/contact" >}})

--- a/exampleSite/content/docs/configuration/site-params/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-tw.md
@@ -139,6 +139,9 @@ authors = ["RazonYang"]
 | `sidebar.tags` | Boolean | `false` | Show the tags widget on the sidebar.
 | `sidebar.archives` | Boolean | `false` | Show the archive widget on the sidebar.
 | `sidebar.authors` | Boolean | `false` | Show the authors widget on the sidebar.
+| `sidebar.postsToggle` | Boolean | `true` | Show the posts toggle on the sidebar.
+| `sidebar.featuredPosts` | Boolean | `false` | Show the featured posts widget on the sidebar.
+| `sidebar.recentPosts` | Boolean | `false` | Show the recent posts widget on the sidebar.
 | **Meta Tag**
 | `metaRobots` | String | - | 空字符串表示禁用。
 | `contact` | Object | - | [聯系表單]({{< ref "docs/layouts/contact" >}})

--- a/exampleSite/content/docs/configuration/site-params/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-tw.md
@@ -1,7 +1,7 @@
 +++
 title = "站點參數"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/site/index.md
+++ b/exampleSite/content/docs/configuration/site/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Site Configuration"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/site/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/site/index.zh-cn.md
@@ -1,7 +1,7 @@
 +++
 title = "站点配置"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/site/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/site/index.zh-tw.md
@@ -1,7 +1,7 @@
 +++
 title = "配置"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/structure/index.md
+++ b/exampleSite/content/docs/configuration/structure/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Configuration Structure"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/structure/index.zh-cn.md
+++ b/exampleSite/content/docs/configuration/structure/index.zh-cn.md
@@ -1,7 +1,7 @@
 +++
 title = "配置结构"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/configuration/structure/index.zh-tw.md
+++ b/exampleSite/content/docs/configuration/structure/index.zh-tw.md
@@ -1,7 +1,7 @@
 +++
 title = "配置結構"
 date = 2021-11-27T19:53:24+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/content/index.md
+++ b/exampleSite/content/docs/content/index.md
@@ -3,7 +3,7 @@ title = "Adding Content"
 linkTitle = "Content"
 linkTitleIcon = '<i class="fas fa-newspaper fa-fw"></i>'
 date = 2021-12-04T10:43:39+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/content/index.zh-cn.md
+++ b/exampleSite/content/docs/content/index.zh-cn.md
@@ -3,7 +3,7 @@ title = "添加内容"
 linkTitle = "内容"
 linkTitleIcon = '<i class="fas fa-newspaper fa-fw"></i>'
 date = 2021-12-04T10:43:39+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/content/index.zh-tw.md
+++ b/exampleSite/content/docs/content/index.zh-tw.md
@@ -3,7 +3,7 @@ title = "添加內容"
 linkTitle = "內容"
 linkTitleIcon = '<i class="fas fa-newspaper fa-fw"></i>'
 date = 2021-12-04T10:43:39+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/getting-started/installation/hugo-module/index.md
+++ b/exampleSite/content/docs/getting-started/installation/hugo-module/index.md
@@ -2,7 +2,7 @@
 title = "Install via Hugo Module"
 linkTitle = "Hugo Module"
 date = 2022-02-26T17:10:39+02:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/getting-started/installation/hugo-module/index.zh-cn.md
+++ b/exampleSite/content/docs/getting-started/installation/hugo-module/index.zh-cn.md
@@ -2,7 +2,7 @@
 title = "通过 Hugo Module 安装"
 linkTitle = "Hugo Module"
 date = 2022-02-26T17:10:39+02:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/getting-started/installation/hugo-module/index.zh-tw.md
+++ b/exampleSite/content/docs/getting-started/installation/hugo-module/index.zh-tw.md
@@ -2,7 +2,7 @@
 title = "通過 via Hugo Module 安裝"
 linkTitle = "Hugo Module"
 date = 2022-02-26T17:10:39+02:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/image-processing/index.md
+++ b/exampleSite/content/docs/image-processing/index.md
@@ -8,6 +8,7 @@ comment = true
 toc = true
 reward = true
 carousel = true
+featured = true
 categories = [
   "Markdown"
 ]

--- a/exampleSite/content/docs/image-processing/index.zh-cn.md
+++ b/exampleSite/content/docs/image-processing/index.zh-cn.md
@@ -7,6 +7,7 @@ comment = true
 toc = true
 reward = true
 carousel = true
+featured = true
 categories = [
   "Markdown"
 ]

--- a/exampleSite/content/docs/image-processing/index.zh-tw.md
+++ b/exampleSite/content/docs/image-processing/index.zh-tw.md
@@ -7,6 +7,7 @@ comment = true
 toc = true
 reward = true
 carousel = true
+featured = true
 categories = [
   "Markdown"
 ]

--- a/exampleSite/content/docs/look-and-feel/index.md
+++ b/exampleSite/content/docs/look-and-feel/index.md
@@ -2,7 +2,7 @@
 title = "Look and Feel"
 linkTitleIcon = '<i class="fas fa-palette fa-fw"></i>'
 date = 2021-12-03T19:42:57+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/look-and-feel/index.zh-cn.md
+++ b/exampleSite/content/docs/look-and-feel/index.zh-cn.md
@@ -2,7 +2,7 @@
 title = "观感"
 linkTitleIcon = '<i class="fas fa-palette fa-fw"></i>'
 date = 2021-12-03T19:42:57+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/look-and-feel/index.zh-tw.md
+++ b/exampleSite/content/docs/look-and-feel/index.zh-tw.md
@@ -2,7 +2,7 @@
 title = "觀感"
 linkTitleIcon = '<i class="fas fa-palette fa-fw"></i>'
 date = 2021-12-03T19:42:57+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/shortcodes/media/index.md
+++ b/exampleSite/content/docs/shortcodes/media/index.md
@@ -2,7 +2,7 @@
 title = "Media Shortcodes"
 date = "2020-10-22"
 description = "A detailed description of media shortcodes"
-featured = true
+featured = false
 categories = [
   "Shortcode"
 ]

--- a/exampleSite/content/docs/shortcodes/online-ide/index.md
+++ b/exampleSite/content/docs/shortcodes/online-ide/index.md
@@ -2,7 +2,7 @@
 title = "Online IDE Shortcodes"
 date = "2020-10-22"
 description = "A detailed description of online IDE shortcodes"
-featured = true
+featured = false
 categories = [
   "Shortcode"
 ]

--- a/exampleSite/content/docs/widgets/comments/index.md
+++ b/exampleSite/content/docs/widgets/comments/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Comments Widget"
 date = 2021-11-27T19:54:29+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/widgets/comments/index.zh-cn.md
+++ b/exampleSite/content/docs/widgets/comments/index.zh-cn.md
@@ -1,7 +1,7 @@
 +++
 title = "评论小部件"
 date = 2021-11-27T19:54:29+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/docs/widgets/comments/index.zh-tw.md
+++ b/exampleSite/content/docs/widgets/comments/index.zh-tw.md
@@ -1,7 +1,7 @@
 +++
 title = "評論小部件"
 date = 2021-11-27T19:54:29+08:00
-featured = true
+featured = false
 comment = true
 toc = true
 reward = true

--- a/exampleSite/content/posts/rich-content/index.md
+++ b/exampleSite/content/posts/rich-content/index.md
@@ -3,7 +3,7 @@ author = "Hugo Authors"
 title = "Rich Content"
 date = "2019-03-10"
 description = "A brief description of Hugo Shortcodes"
-featured = true
+featured = false
 categoories = [
   "Shortcode"
 ]

--- a/layouts/partials/docs/post.html
+++ b/layouts/partials/docs/post.html
@@ -16,4 +16,5 @@
 {{- partial "post/nav" . -}}
 </article>
 {{- partial "post/copyright/index" . -}}
+{{- partial "post/related-posts" . -}}
 {{- partial "post/comments" . -}}

--- a/layouts/partials/post/related-posts.html
+++ b/layouts/partials/post/related-posts.html
@@ -9,9 +9,12 @@
     <div class="card-body">
       <ul class="post-list list-unstyled">
         {{- range . -}}
-        <li>
-          <a href="{{ .Permalink }}">{{ partial "helpers/title" . }}</a>
-          <span class="float-end post-date">{{- partial "helpers/post-date" . -}}</span>
+        <li class="mb-3 border-bottom">
+          <a class="post-title" href="{{ .Permalink }}">
+            {{ partial "helpers/title" . }}
+          </a>
+          <span class="float-end post-date text-muted">{{ partial "helpers/post-date" . }}</span>
+          <div class="post-summary my-3">{{ partial "post/excerpt" . }}</div>
         </li>
         {{- end -}}
       </ul>

--- a/layouts/partials/post/related-posts.html
+++ b/layouts/partials/post/related-posts.html
@@ -13,7 +13,7 @@
           <a class="post-title" href="{{ .Permalink }}">
             {{ partial "helpers/title" . }}
           </a>
-          <span class="float-end post-date text-muted">{{ partial "helpers/post-date" . }}</span>
+          <span class="post-meta post-date float-end">{{ partial "helpers/post-date" . }}</span>
           <div class="post-summary my-3">{{ partial "post/excerpt" . }}</div>
         </li>
         {{- end -}}

--- a/layouts/partials/sidebar/featured-posts.html
+++ b/layouts/partials/sidebar/featured-posts.html
@@ -1,5 +1,5 @@
 {{- $count := default .Params.featuredPostCount .Site.Params.featuredPostCount }}
-{{- if $count }}
+{{- if and $count (default false .Site.Params.sidebar.featuredPosts) }}
   {{- $featuredPosts := first $count (where (where site.RegularPages "Type" "in" site.Params.mainSections) ".Params.featured" "eq" true) }}
   {{- with $featuredPosts }}
   <section class="featured-posts row card component">

--- a/layouts/partials/sidebar/main.html
+++ b/layouts/partials/sidebar/main.html
@@ -1,5 +1,6 @@
 {{- partial "sidebar/profile" . }}
 {{- partialCached "sidebar/taxonomies-toggle" . }}
+{{- partialCached "sidebar/posts-toggle" . }}
 {{- if ne "content" .Site.Params.tocPosition }}
 {{- partial "sidebar/toc" . }}
 {{- end }}

--- a/layouts/partials/sidebar/posts-toggle.html
+++ b/layouts/partials/sidebar/posts-toggle.html
@@ -1,4 +1,3 @@
-
 {{- if default true .Site.Params.sidebar.postsToggle }}
 {{- $recentCount := default .Params.recentPostCount .Site.Params.recentPostCount }}
 {{- $recentSections := .Site.Params.mainSections }}

--- a/layouts/partials/sidebar/posts-toggle.html
+++ b/layouts/partials/sidebar/posts-toggle.html
@@ -1,0 +1,90 @@
+
+{{- if default true .Site.Params.sidebar.postsToggle }}
+{{- $recentCount := default .Params.recentPostCount .Site.Params.recentPostCount }}
+{{- $recentSections := .Site.Params.mainSections }}
+{{- if in (slice "posts" "docs") .Type }}
+  {{- $recentSections = slice .Type }}
+{{- end }}
+{{- $recentPosts := slice }}
+{{- if $recentCount }}
+  {{- $recentPosts = first $recentCount (where site.RegularPages.ByDate.Reverse "Type" "in" $recentSections) }}
+{{- end }}
+
+{{- $featuredPosts := slice }}
+{{- $featuredcount := default .Params.featuredPostCount .Site.Params.featuredPostCount }}
+{{- if $featuredcount }}
+  {{- $featuredPosts = first $featuredcount (where (where site.RegularPages "Type" "in" site.Params.mainSections) ".Params.featured" "eq" true) }}
+{{- end }}
+
+{{- if or $featuredPosts $recentPosts }}
+<section class="taxonomies row card component">
+    <div class="card-body">
+        <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
+            {{- if $featuredPosts }}
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="featured-posts-tab" data-bs-toggle="tab" data-bs-target="#featured-posts" 
+                    type="button" role="tab" aria-controls="featured-posts" aria-selected="true">
+                    {{ i18n "featured_posts" }}
+                </button>
+            </li>
+            {{- end }}
+            {{- if $recentPosts }}
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="recent-posts-tab" data-bs-toggle="tab" data-bs-target="#recent-posts" 
+                    type="button" role="tab" aria-controls="recent-posts" aria-selected="true">
+                    {{ i18n "recent_posts" }}
+                </button>
+            </li>
+            {{- end }}
+        </ul>
+          
+        <div class="tab-content mt-3">
+            {{- with $featuredPosts }}
+            <div class="tab-pane active" id="featured-posts" role="tabpanel" aria-labelledby="featured-posts-tab" tabindex="0">
+                <ul class="post-list list-unstyled ms-1">
+                {{- range . }}
+                  <li class="mb-2">
+                    {{- template "post-item" . }}
+                  </li>
+                {{- end }}
+                </ul>
+            </div>
+            {{- end }}
+            {{- with $recentPosts }}
+            <div class="tab-pane" id="recent-posts" role="tabpanel" aria-labelledby="recent-posts-tab" tabindex="0">
+                <ul class="post-list list-unstyled ms-1">
+                {{- range . }}
+                  <li class="mb-2">
+                    {{- template "post-item" . }}
+                  </li>
+                {{- end }}
+                </ul>
+            </div>
+            {{- end }}
+        </div>
+    </div>
+</section>
+{{- end }}
+{{- end -}}
+
+{{- define "post-item" }}
+    {{- $thumbnail := false }}
+    {{- if isset .Params.images 0 }}{{ $thumbnail = true }}{{ end }}
+    {{- $images := .Resources.ByType "image" -}}
+    {{- $featured := $images.GetMatch "*feature*" -}}
+    {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
+    {{- with $featured -}}{{ $thumbnail = true }}{{ end }}
+    <div class="d-flex">
+        {{- if $thumbnail }}
+        <div class="flex-shrink-0 d-flex justify-content-center align-items-center" style="max-width: 100px">
+            {{- partial "post/thumbnail" . }}
+        </div>
+        {{- end }}
+        <div class="flex-grow-1 d-flex flex-column h-auto justify-content-center{{ if $thumbnail }} ms-3{{ end }}">
+            <a class="post-title" href="{{ .Permalink }}">{{ partial "helpers/title" . }}</a>
+            <div class="post-meta mt-2">
+                <span class="post-date">{{ .Date | time.Format $.Site.Params.dateFormat }}</span>
+            </div>
+        </div>
+    </div>
+{{- end }}

--- a/layouts/partials/sidebar/recent-posts.html
+++ b/layouts/partials/sidebar/recent-posts.html
@@ -3,7 +3,7 @@
 {{- if in (slice "posts" "docs") .Type }}
   {{- $sections = slice .Type }}
 {{- end }}
-{{- if $count }}
+{{- if and $count (default false .Site.Params.sidebar.recentPosts) }}
 <section class="recent-posts row card component">
   <div class="card-header">
     <h2 class="card-title my-2 fs-4 text-surface">{{ i18n "recent_posts" }}</h2>

--- a/layouts/partials/sidebar/taxonomies-toggle.html
+++ b/layouts/partials/sidebar/taxonomies-toggle.html
@@ -2,7 +2,7 @@
 {{- if default true .Site.Params.sidebar.taxonomiesToggle }}
 <section class="taxonomies row card component">
     <div class="card-body">
-        <ul class="nav nav-tabs" id="myTab" role="tablist">
+        <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
             {{- $counter := 0 }}
             {{- range $expected := $.Site.Params.sidebarTaxonomies }}
             {{- range $key, $value := $.Site.Taxonomies }}


### PR DESCRIPTION
The posts toggle widget is enabled by default. You can switch back to the old widgets by following parameters.

```toml
[sidebar]
  postsToggle = false # Disable posts toggle
  featuredPosts = true # Enable featured posts widget
  recentPosts = true # Enable featured posts widget
```