### PR TITLE
Collapse all sidebar widgets on small devices

### DIFF
--- a/assets/main/scss/_profile.scss
+++ b/assets/main/scss/_profile.scss
@@ -1,6 +1,5 @@
 .profile {
   color: var(--#{$prefix}secondary-text-on-surface) !important;
-  padding: 0.5rem 0 0;
 
   .profile-avatar {
     height: 120px;
@@ -47,9 +46,5 @@
     @include media-breakpoint-down(sm) {
       text-align: center;
     }
-  }
-
-  .social-links {
-    justify-content: start !important;
   }
 }

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -167,6 +167,12 @@ other = "{{ .Count }} posts in total"
 [post_date]
 other = "created on {{ .createdOn }}{{ with .updatedOn }}, updated on {{ . }}{{ end }}."
 
+[posts]
+other = "Posts"
+
+[profile]
+other = "Profile"
+
 [read_more]
 other = "Read More"
 
@@ -214,6 +220,9 @@ other = "Contents"
 
 [tags]
 other = "Tags"
+
+[taxonomies]
+other = "Taxonomies"
 
 [tipeee]
 other = "Tipeee"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -157,6 +157,12 @@ other = "总共 {{ .Count }} 篇文章"
 [post_date]
 other = "创建于 {{ .createdOn }}{{ with .updatedOn }}，更新于 {{ . }}{{ end }}。"
 
+[posts]
+other = "文章"
+
+[profile]
+other = "Profile"
+
 [read_more]
 other = "阅读更多"
 
@@ -201,6 +207,9 @@ other = "目录"
 
 [tags]
 other = "标签"
+
+[taxonomies]
+other = "Taxonomies"
 
 [try_again]
 other = "再试一次"

--- a/i18n/zh-hans.toml
+++ b/i18n/zh-hans.toml
@@ -157,6 +157,12 @@ other = "总共 {{ .Count }} 篇文章"
 [post_date]
 other = "创建于 {{ .createdOn }}{{ with .updatedOn }}，更新于 {{ . }}{{ end }}。"
 
+[posts]
+other = "文章"
+
+[profile]
+other = "Profile"
+
 [read_more]
 other = "阅读更多"
 
@@ -201,6 +207,9 @@ other = "目录"
 
 [tags]
 other = "标签"
+
+[taxonomies]
+other = "Taxonomies"
 
 [try_again]
 other = "再试一次"

--- a/i18n/zh-hant.toml
+++ b/i18n/zh-hant.toml
@@ -157,6 +157,12 @@ other = "總共 {{ .Count }} 篇文章"
 [post_date]
 other = "創建於 {{ .createdOn }}{{ with .updatedOn }}，更新於 {{ . }}{{ end }}。"
 
+[posts]
+other = "文章"
+
+[profile]
+other = "Profile"
+
 [read_more]
 other = "閱讀更多"
 
@@ -201,6 +207,9 @@ other = "目錄"
 
 [tags]
 other = "標籤"
+
+[taxonomies]
+other = "Taxonomies"
 
 [try_again]
 other = "再試一次"

--- a/i18n/zh-hk.toml
+++ b/i18n/zh-hk.toml
@@ -157,6 +157,12 @@ other = "總共 {{ .Count }} 篇文章"
 [post_date]
 other = "創建於 {{ .createdOn }}{{ with .updatedOn }}，更新於 {{ . }}{{ end }}。"
 
+[posts]
+other = "文章"
+
+[profile]
+other = "Profile"
+
 [read_more]
 other = "閱讀更多"
 
@@ -201,6 +207,9 @@ other = "目錄"
 
 [tags]
 other = "標籤"
+
+[taxonomies]
+other = "Taxonomies"
 
 [try_again]
 other = "再試一次"

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -157,6 +157,12 @@ other = "總共 {{ .Count }} 篇文章"
 [post_date]
 other = "創建於 {{ .createdOn }}{{ with .updatedOn }}，更新於 {{ . }}{{ end }}。"
 
+[posts]
+other = "文章"
+
+[profile]
+other = "Profile"
+
 [read_more]
 other = "閱讀更多"
 
@@ -201,6 +207,9 @@ other = "目錄"
 
 [tags]
 other = "標籤"
+
+[taxonomies]
+other = "Taxonomies"
 
 [try_again]
 other = "再試一次"

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -8,6 +8,7 @@
 {{- $path := replace .Permalink $baseURL "" -}}
 {{- $date := split $path "/" -}}
 {{- $pages := where .Site.RegularPages "Type" "in" .Site.Params.mainSections -}}
+{{- partial "sidebar" . -}}
 <div class="col-lg-8 mb-4">
   <div class="container">
     {{- partial "breadcrumb" . -}}
@@ -20,5 +21,4 @@
     </div>
   </div>
 </div>
-{{- partial "sidebar" . -}}
 {{ end }}

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -1,4 +1,5 @@
 {{ define "content" }}
+{{- partial "sidebar" . -}}
 <div class="col-lg-8">
     {{- partial "breadcrumb" . -}}
     <div class="contact row component card">
@@ -14,6 +15,5 @@
         </div>
     </div>
 </div>
-{{- partial "sidebar" . -}}
 {{ end }}
   

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,9 @@
 {{ define "content" }}
+{{- partial "sidebar" . -}}
 <div class="col-lg-8">
   <div class="container">
     {{- partial "breadcrumb" . -}}
     {{- partial "post" . -}}
   </div>
 </div>
-{{- partial "sidebar" . -}}
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,4 +1,5 @@
 {{ define "content" }}
+{{- partial "sidebar" . -}}
 <div class="col-lg-8">
   <div class="container">
     {{- partial "breadcrumb" . -}}
@@ -38,5 +39,4 @@
     {{- partial "pagination" . -}}
   </div>
 </div>
-{{- partial "sidebar" . -}}
 {{ end }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
 {{- partial "docs/nav" . -}}
+{{- partial "docs/sidebar" . -}}
 <div class="col-lg-7 ms-auto">
   {{ partial "docs/list" . }}
 </div>
-{{- partial "docs/sidebar" . -}}
 {{ end }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,10 +1,10 @@
 {{ define "content" }}
 {{- partial "docs/nav" . -}}
+{{- partial "docs/sidebar" . -}}
 <div class="col-lg-7 ms-auto">
   <div class="container-fluid">
     {{- partial "breadcrumb" . -}}
     {{- partial "docs/post" . -}}
   </div>
 </div>
-{{- partial "docs/sidebar" . -}}
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
 {{- partial "carousel" . -}}
+{{- partial "sidebar" . -}}
 <div class="col-lg-8">
   {{ partial "list" . }}
 </div>
-{{- partial "sidebar" . -}}
 {{ end }}

--- a/layouts/partials/docs/repo.html
+++ b/layouts/partials/docs/repo.html
@@ -5,34 +5,39 @@
 {{- $subPath := default "" .subPath -}}
 {{- $contentDir := default "content" $.Site.Language.ContentDir -}}
 {{- if $subPath -}}{{ $subPath = printf "/%s" $subPath }}{{- end -}}
-<div class="docs-repo row card component">
-    <div class="card-header">
-        <h2 class="card-title fs-4 my-2 text-surface">{{ i18n "repo_title" }}</h2>
-    </div>
-    <div class="card-body text-secondary-on-surface">
-        <ul class="list-unstyled">
-            {{- if $.File -}}
-            {{- $filePath := printf "%s%s/%s/%s" $branch $subPath $contentDir $.File.Path -}}
-            <li class="mb-1">
-                <a href="{{ printf "%s/blob/%s" $url $filePath }}" target="_blank" rel="noopener noreferrer">
-                    <i class="fas fa-fw fa-file-archive"></i> {{ i18n "repo_action_view" }}
-                </a>
-            </li>
-            <li class="mb-1">
-                <a href="{{ printf "%s/edit/%s" $url $filePath  }}" target="_blank" rel="noopener noreferrer">
-                    <i class="fas fa-fw fa-edit"></i> {{ i18n "repo_action_edit" }}
-                </a>
-            </li>
-            {{- end -}}
-            {{- with $.GitInfo -}}
-            <li class="mb-1">
-                <i class="fas fa-fw fa-code"></i> <a href="{{ printf "%s/commit/%s" $url .Hash }}" target="_blank" rel="noopener noreferrer">{{ .AbbreviatedHash }}</a>
-            </li>
-            <li class="mb-1">
-                <i class="fas fa-fw fa-history"></i> {{ .AuthorDate.Format $dateFormat }}
-            </li>
-            {{- end -}}
-        </ul>
+<div class="accordion">
+    <div class="accordion-item docs-repo row card component">
+        <div class="card-header accordion-header" id="repo-header">
+            <h2 class="card-title fs-4 my-2 text-surface d-none d-lg-block">{{ i18n "repo_title" }}</h2>
+            <button class="accordion-button d-lg-none mb-1 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#repo" aria-expanded="false" aria-controls="repo">
+                {{ i18n "repo_title" }}
+            </button>
+        </div>
+        <div class="card-body collapse accordion-collapse accordion-body text-secondary-on-surface d-lg-block" id="repo" aria-labelledby="repo-header">
+            <ul class="list-unstyled">
+                {{- if $.File -}}
+                {{- $filePath := printf "%s%s/%s/%s" $branch $subPath $contentDir $.File.Path -}}
+                <li class="mb-1">
+                    <a href="{{ printf "%s/blob/%s" $url $filePath }}" target="_blank" rel="noopener noreferrer">
+                        <i class="fas fa-fw fa-file-archive"></i> {{ i18n "repo_action_view" }}
+                    </a>
+                </li>
+                <li class="mb-1">
+                    <a href="{{ printf "%s/edit/%s" $url $filePath  }}" target="_blank" rel="noopener noreferrer">
+                        <i class="fas fa-fw fa-edit"></i> {{ i18n "repo_action_edit" }}
+                    </a>
+                </li>
+                {{- end -}}
+                {{- with $.GitInfo -}}
+                <li class="mb-1">
+                    <i class="fas fa-fw fa-code"></i> <a href="{{ printf "%s/commit/%s" $url .Hash }}" target="_blank" rel="noopener noreferrer">{{ .AbbreviatedHash }}</a>
+                </li>
+                <li class="mb-1">
+                    <i class="fas fa-fw fa-history"></i> {{ .AuthorDate.Format $dateFormat }}
+                </li>
+                {{- end -}}
+            </ul>
+        </div>
     </div>
 </div>
 {{- end -}}

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -1,4 +1,4 @@
-<aside class="sidebar d-flex docs-sidebar col-lg-3 position-sticky">
+<aside class="sidebar d-flex docs-sidebar col-lg-3 position-sticky order-lg-5">
   <div class="container">
     {{ partial "hooks/docs/sidebar-begin" . }}
     {{ partial "docs/toc" . }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<aside class="col-lg-4 sidebar d-flex">
+<aside class="col-lg-4 sidebar d-flex order-lg-5">
   <div class="container d-flex flex-column">
     {{ partial "hooks/sidebar-begin" . }}
     {{ partial "sidebar/main" . }}

--- a/layouts/partials/sidebar/archive.html
+++ b/layouts/partials/sidebar/archive.html
@@ -2,18 +2,23 @@
 {{- $basePath := strings.TrimSuffix "/" (default "/archives" .Site.Params.archive.basePath) }}
 {{- $basePath = printf "/%s/" (strings.TrimPrefix "/" $basePath)  }}
 {{- $archivePage := $.GetPage $basePath }}
-<section class="row card component">
-    <div class="card-header">
-      <h2 class="card-title my-2 fs-4 text-surface">
-          {{- with $archivePage }}
-          <a href="{{ .Permalink }}">{{ i18n "archives" }}</a>
-          {{- else }}
-          {{ i18n "archives" }}
-          {{- end }}
-      </h2>
-    </div>
-    <div class="card-body">
-      {{- partial "sidebar/archive-items" . }}
-    </div>
-</section>
+<div class="accordion">
+  <section class="row card component">
+      <div class="card-header">
+        <h2 class="card-title my-2 fs-4 text-surface d-none d-lg-block">
+            {{- with $archivePage }}
+            <a href="{{ .Permalink }}">{{ i18n "archives" }}</a>
+            {{- else }}
+            {{ i18n "archives" }}
+            {{- end }}
+        </h2>
+        <button class="accordion-button d-lg-none mb-1 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#archives" aria-expanded="false" aria-controls="archives">
+            {{ i18n "archives" }}
+        </button>
+      </div>
+      <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="archives">
+        {{- partial "sidebar/archive-items" . }}
+      </div>
+  </section>
+</div>
 {{- end }}

--- a/layouts/partials/sidebar/featured-posts.html
+++ b/layouts/partials/sidebar/featured-posts.html
@@ -2,19 +2,24 @@
 {{- if and $count (default false .Site.Params.sidebar.featuredPosts) }}
   {{- $featuredPosts := first $count (where (where site.RegularPages "Type" "in" site.Params.mainSections) ".Params.featured" "eq" true) }}
   {{- with $featuredPosts }}
-  <section class="featured-posts row card component">
-    <div class="card-header">
-      <h2 class="card-title my-2 fs-4 text-surface">{{ i18n "featured_posts" }}</h2>
-    </div>
-    <div class="card-body">
-      <ul class="post-list list-unstyled ms-1">
-      {{- range . }}
-        <li class="mb-2">
-          <a href="{{ .Permalink }}">{{ partial "helpers/title" . }}</a>
-        </li>
-      {{- end }}
-      </ul>
-    </div>
-  </section>
+  <div class="accordion">
+    <section class="featured-posts row card component">
+      <div class="card-header">
+        <h2 class="card-title my-2 fs-4 text-surface d-none d-lg-block">{{ i18n "featured_posts" }}</h2>
+        <button class="accordion-button d-lg-none mb-1 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#featured-posts" aria-expanded="false" aria-controls="featured-posts">
+            {{ i18n "featured_posts" }}
+        </button>
+      </div>
+      <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="featured-posts">
+        <ul class="post-list list-unstyled ms-1">
+        {{- range . }}
+          <li class="mb-2">
+            <a href="{{ .Permalink }}">{{ partial "helpers/title" . }}</a>
+          </li>
+        {{- end }}
+        </ul>
+      </div>
+    </section>
+  </div>
   {{- end }}
 {{- end }}

--- a/layouts/partials/sidebar/posts-toggle.html
+++ b/layouts/partials/sidebar/posts-toggle.html
@@ -16,53 +16,60 @@
 {{- end }}
 
 {{- if or $featuredPosts $recentPosts }}
-<section class="taxonomies row card component">
-    <div class="card-body">
-        <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
-            {{- if $featuredPosts }}
-            <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="featured-posts-tab" data-bs-toggle="tab" data-bs-target="#featured-posts" 
-                    type="button" role="tab" aria-controls="featured-posts" aria-selected="true">
-                    {{ i18n "featured_posts" }}
-                </button>
-            </li>
-            {{- end }}
-            {{- if $recentPosts }}
-            <li class="nav-item" role="presentation">
-                <button class="nav-link{{ if not $featuredPosts }} active{{ end }}" id="recent-posts-tab" data-bs-toggle="tab" data-bs-target="#recent-posts" 
-                    type="button" role="tab" aria-controls="recent-posts" aria-selected="true">
-                    {{ i18n "recent_posts" }}
-                </button>
-            </li>
-            {{- end }}
-        </ul>
-          
-        <div class="tab-content mt-3">
-            {{- with $featuredPosts }}
-            <div class="tab-pane active" id="featured-posts" role="tabpanel" aria-labelledby="featured-posts-tab" tabindex="0">
-                <ul class="post-list list-unstyled ms-1">
-                {{- range . }}
-                  <li class="mb-2">
-                    {{- template "post-item" . }}
-                  </li>
-                {{- end }}
-                </ul>
-            </div>
-            {{- end }}
-            {{- with $recentPosts }}
-            <div class="tab-pane{{ if not $featuredPosts }} active{{ end }}" id="recent-posts" role="tabpanel" aria-labelledby="recent-posts-tab" tabindex="0">
-                <ul class="post-list list-unstyled ms-1">
-                {{- range . }}
-                  <li class="mb-2">
-                    {{- template "post-item" . }}
-                  </li>
-                {{- end }}
-                </ul>
-            </div>
-            {{- end }}
+<div class="accordion">
+    <section class="taxonomies row card component accordion-item">
+        <div class="accordion-header card-header">
+            <button class="accordion-button d-lg-none mb-1 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#posts-toggle" aria-expanded="false" aria-controls="posts-toggle">
+                {{ i18n "posts" }}
+            </button>
         </div>
-    </div>
-</section>
+        <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="posts-toggle">
+            <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
+                {{- if $featuredPosts }}
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="featured-posts-tab" data-bs-toggle="tab" data-bs-target="#featured-posts" 
+                        type="button" role="tab" aria-controls="featured-posts" aria-selected="true">
+                        {{ i18n "featured_posts" }}
+                    </button>
+                </li>
+                {{- end }}
+                {{- if $recentPosts }}
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link{{ if not $featuredPosts }} active{{ end }}" id="recent-posts-tab" data-bs-toggle="tab" data-bs-target="#recent-posts" 
+                        type="button" role="tab" aria-controls="recent-posts" aria-selected="true">
+                        {{ i18n "recent_posts" }}
+                    </button>
+                </li>
+                {{- end }}
+            </ul>
+            
+            <div class="tab-content mt-3">
+                {{- with $featuredPosts }}
+                <div class="tab-pane active" id="featured-posts" role="tabpanel" aria-labelledby="featured-posts-tab" tabindex="0">
+                    <ul class="post-list list-unstyled ms-1">
+                    {{- range . }}
+                    <li class="mb-2">
+                        {{- template "post-item" . }}
+                    </li>
+                    {{- end }}
+                    </ul>
+                </div>
+                {{- end }}
+                {{- with $recentPosts }}
+                <div class="tab-pane{{ if not $featuredPosts }} active{{ end }}" id="recent-posts" role="tabpanel" aria-labelledby="recent-posts-tab" tabindex="0">
+                    <ul class="post-list list-unstyled ms-1">
+                    {{- range . }}
+                    <li class="mb-2">
+                        {{- template "post-item" . }}
+                    </li>
+                    {{- end }}
+                    </ul>
+                </div>
+                {{- end }}
+            </div>
+        </div>
+    </section>
+</div>
 {{- end }}
 {{- end -}}
 

--- a/layouts/partials/sidebar/profile/compact.html
+++ b/layouts/partials/sidebar/profile/compact.html
@@ -1,8 +1,20 @@
-<div class="profile profile-compact card row component">
-  <div class="col-lg-5 d-flex align-items-center justify-content-center">
-    {{- partial "sidebar/profile/avatar" . -}}
-  </div>
-  <div class="col-lg-7 profile-meta">
-    {{- partial "sidebar/profile/meta" . -}}
+<div class="accordion">
+  <div class="accordion-item profile profile-compact card row component">
+    <div class="accordion-header card-header border-0" id="profile-header">
+      <button class="accordion-button d-lg-none mb-2 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#profile" aria-expanded="false" aria-controls="profile">
+        {{ i18n "profile" }}
+      </button>
+    </div>
+    <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="profile" aria-labelledby="profile-header">
+      <div class="d-flex">
+        <div class="d-flex flex-shrink-0 justify-content-center align-items-center">
+          {{- partial "sidebar/profile/avatar" . -}}
+        </div>
+        <div class="profile-meta flex-grow-1 ms-3 text-center">
+          {{- partial "sidebar/profile/meta" . -}}
+        </div>
+      </div>
+      {{- partial "sidebar/profile/social-links" . -}}
+    </div>
   </div>
 </div>

--- a/layouts/partials/sidebar/profile/default.html
+++ b/layouts/partials/sidebar/profile/default.html
@@ -1,10 +1,18 @@
-<div class="card row text-center profile component">
-  <div class="card-body">
-    <div class="col-12 d-flex align-items-center justify-content-center">
-      {{- partial "sidebar/profile/avatar" . -}}
+<div class="accordion">
+  <div class="accordion-item card row text-center profile component">
+    <div class="accordion-header card-header border-0" id="profile-header">
+      <button class="accordion-button d-lg-none mb-2 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#profile" aria-expanded="false" aria-controls="profile">
+        {{ i18n "profile" }}
+      </button>
     </div>
-    <div class="col-12 profile-meta">
-      {{- partial "sidebar/profile/meta" . -}}
+    <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="profile" aria-labelledby="profile-header">
+      <div class="col-12 d-flex align-items-center justify-content-center">
+        {{- partial "sidebar/profile/avatar" . -}}
+      </div>
+      <div class="col-12 profile-meta">
+        {{- partial "sidebar/profile/meta" . -}}
+      </div>
+      {{- partial "sidebar/profile/social-links" . -}}
     </div>
   </div>
 </div>

--- a/layouts/partials/sidebar/profile/meta.html
+++ b/layouts/partials/sidebar/profile/meta.html
@@ -19,7 +19,4 @@
 {{- with $.GetPage "contact" -}}
 <div class="profile-contact text-primary"><i class="fas fa-fw fa-question-circle"></i><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></div>
 {{- end -}}
-{{- with .social -}}
-{{- partial "helpers/social-links" (dict "links" . "size" "fa-2x" "OutputFormats" $.OutputFormats "home" ($.GetPage "/") "params" $.Site.Params) -}}
-{{- end -}}
 {{- end -}}

--- a/layouts/partials/sidebar/profile/social-links.html
+++ b/layouts/partials/sidebar/profile/social-links.html
@@ -1,0 +1,3 @@
+{{- with .Site.Author.social -}}
+{{- partial "helpers/social-links" (dict "class" "mt-1 justify-content-between" "links" . "size" "fa-2x" "OutputFormats" $.OutputFormats "home" ($.GetPage "/") "params" $.Site.Params) -}}
+{{- end -}}

--- a/layouts/partials/sidebar/recent-posts.html
+++ b/layouts/partials/sidebar/recent-posts.html
@@ -4,18 +4,23 @@
   {{- $sections = slice .Type }}
 {{- end }}
 {{- if and $count (default false .Site.Params.sidebar.recentPosts) }}
-<section class="recent-posts row card component">
-  <div class="card-header">
-    <h2 class="card-title my-2 fs-4 text-surface">{{ i18n "recent_posts" }}</h2>
-  </div>
-  <div class="card-body">
-    <ul class="post-list list-unstyled ms-1">
-    {{- range first $count (where site.RegularPages.ByDate.Reverse "Type" "in" $sections) }}
-      <li class="mb-2">
-        <a href="{{ .Permalink }}">{{ partial "helpers/title" . }}</a>
-      </li>
-    {{- end }}
-    </ul>
-  </div>
-</section>
+<div class="accordion">
+  <section class="recent-posts row card component">
+    <div class="card-header">
+      <h2 class="card-title my-2 fs-4 text-surface d-none d-lg-block">{{ i18n "recent_posts" }}</h2>
+      <button class="accordion-button d-lg-none mb-1 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#recent-posts" aria-expanded="false" aria-controls="recent-posts">
+          {{ i18n "recent_posts" }}
+      </button>
+    </div>
+    <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="recent-posts">
+      <ul class="post-list list-unstyled ms-1">
+      {{- range first $count (where site.RegularPages.ByDate.Reverse "Type" "in" $sections) }}
+        <li class="mb-2">
+          <a href="{{ .Permalink }}">{{ partial "helpers/title" . }}</a>
+        </li>
+      {{- end }}
+      </ul>
+    </div>
+  </section>
+</div>
 {{- end }}

--- a/layouts/partials/sidebar/taxonomies-toggle.html
+++ b/layouts/partials/sidebar/taxonomies-toggle.html
@@ -1,77 +1,84 @@
 
 {{- if default true .Site.Params.sidebar.taxonomiesToggle }}
-<section class="taxonomies row card component">
-    <div class="card-body">
-        <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
-            {{- $counter := 0 }}
-            {{- range $expected := $.Site.Params.sidebarTaxonomies }}
-            {{- range $key, $value := $.Site.Taxonomies }}
-              {{- if eq $key $expected }}
-              {{- $countParams := dict "categories" "categoryCount" "tags" "tagCount" "series" "seriesCount" }}
-              {{- $param := default "" (index $countParams $key) }}
-              {{- $taxonomyCount := default 10 ($.Site.Param $param) }}
-              {{- if $taxonomyCount }}
-                {{- with $value.ByCount }}
+<div class="accordion">
+    <section class="taxonomies row card component accordion-item">
+        <div class="accordion-header card-header">
+            <button class="accordion-button d-lg-none mb-1 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#taxonomies-toggle" aria-expanded="false" aria-controls="taxonomies-toggle">
+                {{ i18n "taxonomies" }}
+            </button>
+        </div>
+        <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="taxonomies-toggle">
+            <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
+                {{- $counter := 0 }}
+                {{- range $expected := $.Site.Params.sidebarTaxonomies }}
+                {{- range $key, $value := $.Site.Taxonomies }}
+                {{- if eq $key $expected }}
+                {{- $countParams := dict "categories" "categoryCount" "tags" "tagCount" "series" "seriesCount" }}
+                {{- $param := default "" (index $countParams $key) }}
+                {{- $taxonomyCount := default 10 ($.Site.Param $param) }}
+                {{- if $taxonomyCount }}
+                    {{- with $value.ByCount }}
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link{{ if eq $counter 0 }} active{{ end }}" id="taxonomy{{ $key | title }}Tab" data-bs-toggle="tab" data-bs-target="#taxonomy{{ $key | title }}" 
+                            type="button" role="tab" aria-controls="{{ i18n $key }}" aria-selected="true">
+                            {{ i18n $key }}
+                        </button>
+                    </li>
+                    {{- $counter = add $counter 1 }}
+                    {{- end }}
+                {{- end }}
+                {{- end }}
+                {{- end }}
+                {{- end }}
                 <li class="nav-item" role="presentation">
-                    <button class="nav-link{{ if eq $counter 0 }} active{{ end }}" id="taxonomy{{ $key | title }}Tab" data-bs-toggle="tab" data-bs-target="#taxonomy{{ $key | title }}" 
-                        type="button" role="tab" aria-controls="{{ i18n $key }}" aria-selected="true">
-                        {{ i18n $key }}
+                    <button class="nav-link" id="taxonomyArchivesTab" data-bs-toggle="tab" data-bs-target="#taxonomyArchive" 
+                        type="button" role="tab" aria-controls="taxonomyArchives" aria-selected="true">
+                        {{ i18n "archives" }}
                     </button>
                 </li>
-                {{- $counter = add $counter 1 }}
-                {{- end }}
-              {{- end }}
-              {{- end }}
-            {{- end }}
-            {{- end }}
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="taxonomyArchivesTab" data-bs-toggle="tab" data-bs-target="#taxonomyArchive" 
-                    type="button" role="tab" aria-controls="taxonomyArchives" aria-selected="true">
-                    {{ i18n "archives" }}
-                </button>
-            </li>
-        </ul>
-          
-        <div class="tab-content mt-3">
-            {{- $counter := 0 }}
-            {{- range $expected := $.Site.Params.sidebarTaxonomies }}
-            {{- range $key, $value := $.Site.Taxonomies }}
-            {{- if eq $key $expected }}
-            {{- $countParams := dict "categories" "categoryCount" "tags" "tagCount" "series" "seriesCount" }}
-            {{- $param := default "" (index $countParams $key) }}
-            {{- $taxonomyCount := default 10 ($.Site.Param $param) }}
-            {{- if $taxonomyCount }}
-                {{- with $value.ByCount }}
-                <div class="tab-pane{{ if eq $counter 0 }} active{{ end }}" id="taxonomy{{ $key | title }}" role="tabpanel" aria-labelledby="taxonomy{{ $key | title }}Tab" tabindex="0">
-                    {{- $count := 0 }}
-                    {{- range . }}
-                    {{- if and (lt $count $taxonomyCount) (ne .Name "") }}
-                    <a href="{{ .Page.Permalink }}" class="btn btn-sm btn-secondary post-taxonomy post-{{ $key | singularize }} me-2 mb-2" title="{{ .Page.Title }}">
-                        {{ .Page.Title }}
-                        {{- if $.Site.Params.countTaxonomyPosts }}
-                        <span class="badge badge-sm text-secondary bg-white ms-1">{{ .Count }}</span>
+            </ul>
+            
+            <div class="tab-content mt-3">
+                {{- $counter := 0 }}
+                {{- range $expected := $.Site.Params.sidebarTaxonomies }}
+                {{- range $key, $value := $.Site.Taxonomies }}
+                {{- if eq $key $expected }}
+                {{- $countParams := dict "categories" "categoryCount" "tags" "tagCount" "series" "seriesCount" }}
+                {{- $param := default "" (index $countParams $key) }}
+                {{- $taxonomyCount := default 10 ($.Site.Param $param) }}
+                {{- if $taxonomyCount }}
+                    {{- with $value.ByCount }}
+                    <div class="tab-pane{{ if eq $counter 0 }} active{{ end }}" id="taxonomy{{ $key | title }}" role="tabpanel" aria-labelledby="taxonomy{{ $key | title }}Tab" tabindex="0">
+                        {{- $count := 0 }}
+                        {{- range . }}
+                        {{- if and (lt $count $taxonomyCount) (ne .Name "") }}
+                        <a href="{{ .Page.Permalink }}" class="btn btn-sm btn-secondary post-taxonomy post-{{ $key | singularize }} me-2 mb-2" title="{{ .Page.Title }}">
+                            {{ .Page.Title }}
+                            {{- if $.Site.Params.countTaxonomyPosts }}
+                            <span class="badge badge-sm text-secondary bg-white ms-1">{{ .Count }}</span>
+                            {{- end }}
+                        </a>
+                        {{- $count = add $count 1 }}
                         {{- end }}
-                    </a>
-                    {{- $count = add $count 1 }}
+                        {{- end }}
+                        {{- if gt (len $value) $taxonomyCount }}
+                        <a href="{{ absLangURL (urlize $key) }}" class="btn btn-sm btn-secondary post-taxonomy post-{{ $key | singularize }} me-2 mb-2" title='{{ i18n "all" | upper }}'>
+                        {{ i18n "all" | upper }}
+                        <span class="badge badge-sm text-secondary bg-white ms-1">{{ len $value }}</span>
+                        </a>
+                        {{- end }}
+                    </div>
+                    {{- $counter = add $counter 1 }}
                     {{- end }}
-                    {{- end }}
-                    {{- if gt (len $value) $taxonomyCount }}
-                    <a href="{{ absLangURL (urlize $key) }}" class="btn btn-sm btn-secondary post-taxonomy post-{{ $key | singularize }} me-2 mb-2" title='{{ i18n "all" | upper }}'>
-                    {{ i18n "all" | upper }}
-                    <span class="badge badge-sm text-secondary bg-white ms-1">{{ len $value }}</span>
-                    </a>
-                    {{- end }}
-                </div>
-                {{- $counter = add $counter 1 }}
                 {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
-            <div class="tab-pane" id="taxonomyArchive" role="tabpanel" aria-labelledby="taxonomyArchiveTab" tabindex="0">
-                {{- partial "sidebar/archive-items" . }}
+                {{- end }}
+                {{- end }}
+                {{- end }}
+                <div class="tab-pane" id="taxonomyArchive" role="tabpanel" aria-labelledby="taxonomyArchiveTab" tabindex="0">
+                    {{- partial "sidebar/archive-items" . }}
+                </div>
             </div>
         </div>
-    </div>
-</section>
+    </section>
+</div>
 {{- end -}}

--- a/layouts/partials/sidebar/taxonomies.html
+++ b/layouts/partials/sidebar/taxonomies.html
@@ -10,35 +10,40 @@
   {{- $taxonomyCount := default 10 ($.Site.Param $param) }}
   {{- if $taxonomyCount }}
     {{- with $value.ByCount }}
-    <section class="{{ $key }}-taxonomies row card component">
-      <div class="card-header">
-        <h2 class="card-title my-2 fs-4 text-surface">
-          <a href="{{ absLangURL (urlize $key) }}">{{ i18n $key }}</a>
-        </h2>
-      </div>
-      <div class="card-body">
-        <div class="py-2">
-        {{- $count := 0 }}
-        {{- range . }}
-          {{- if and (lt $count $taxonomyCount) (ne .Name "") }}
-          <a href="{{ .Page.Permalink }}" class="btn btn-sm btn-secondary post-taxonomy post-{{ $key | singularize }} me-2 mb-2" title="{{ .Page.Title }}">
-            {{ .Page.Title }}
-            {{- if $.Site.Params.countTaxonomyPosts }}
-              <span class="badge badge-sm text-secondary bg-white ms-1">{{ .Count }}</span>
+      <div class="accordion">
+        <section class="{{ $key }}-taxonomies row card component">
+          <div class="card-header">
+            <h2 class="card-title my-2 fs-4 text-surface d-none d-lg-block">
+              <a href="{{ absLangURL (urlize $key) }}">{{ i18n $key }}</a>
+            </h2>
+            <button class="accordion-button d-lg-none mb-1 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#taxonomy-{{ $key }}" aria-expanded="false" aria-controls="taxonomy-{{ $key }}">
+                {{ i18n $key }}
+            </button>
+          </div>
+          <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="taxonomy-{{ $key }}">
+            <div class="py-2">
+            {{- $count := 0 }}
+            {{- range . }}
+              {{- if and (lt $count $taxonomyCount) (ne .Name "") }}
+              <a href="{{ .Page.Permalink }}" class="btn btn-sm btn-secondary post-taxonomy post-{{ $key | singularize }} me-2 mb-2" title="{{ .Page.Title }}">
+                {{ .Page.Title }}
+                {{- if $.Site.Params.countTaxonomyPosts }}
+                  <span class="badge badge-sm text-secondary bg-white ms-1">{{ .Count }}</span>
+                {{- end }}
+              </a>
+              {{- $count = add $count 1 }}
+              {{- end }}
             {{- end }}
-          </a>
-          {{- $count = add $count 1 }}
-          {{- end }}
-        {{- end }}
-        {{- if gt (len $value) $taxonomyCount }}
-        <a href="{{ absLangURL (urlize $key) }}" class="btn btn-sm btn-secondary post-taxonomy post-{{ $key | singularize }} me-2 mb-2" title='{{ i18n "all" | upper }}'>
-          {{ i18n "all" | upper }}
-          <span class="badge badge-sm text-secondary bg-white ms-1">{{ len $value }}</span>
-        </a>
-        {{- end }}
-        </div>
+            {{- if gt (len $value) $taxonomyCount }}
+            <a href="{{ absLangURL (urlize $key) }}" class="btn btn-sm btn-secondary post-taxonomy post-{{ $key | singularize }} me-2 mb-2" title='{{ i18n "all" | upper }}'>
+              {{ i18n "all" | upper }}
+              <span class="badge badge-sm text-secondary bg-white ms-1">{{ len $value }}</span>
+            </a>
+            {{- end }}
+            </div>
+          </div>
+        </section>
       </div>
-    </section>
     {{- end }}
   {{- end }}
   {{- end }}

--- a/layouts/partials/sidebar/toc.html
+++ b/layouts/partials/sidebar/toc.html
@@ -2,12 +2,17 @@
 {{- $toc := .TableOfContents -}}
 {{- $valid := and $toc (and (ne $toc "<nav id=\"TableOfContents\"></nav>") (gt .WordCount .Site.Params.tocWordCount)) -}}
 {{- if and $enable $valid -}}
-<div class="post-toc row mb-4 card component" id="postTOC">
-  <div class="card-header">
-    <h2 class="card-title fs-4 my-2 text-surface">{{ i18n "table_of_contents" }}</h2>
-  </div>
-  <div class="card-body">
-    {{ $toc }}
+<div class="accordion">
+  <div class="accordion-item post-toc row mb-4 card component" id="postTOC">
+    <div class="card-header accordion-header">
+      <h2 class="card-title fs-4 my-2 text-surface d-none d-lg-block">{{ i18n "table_of_contents" }}</h2>
+      <button class="accordion-button d-lg-none mb-1 collapsed shadow-none px-3 py-2" type="button" data-bs-toggle="collapse" data-bs-target="#post-toc" aria-expanded="false" aria-controls="post-toc">
+        {{ i18n "table_of_contents" }}
+      </button>
+    </div>
+    <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="post-toc" aria-labelledby="post-toc-header">
+      {{ $toc }}
+    </div>
   </div>
 </div>
 {{- end -}}


### PR DESCRIPTION
The sidebar widgets appear above of content on small devices, and those widgets will be collapsed since they are less important than content.