### PR TITLE
Fix the social links nav (header)

### DIFF
--- a/layouts/partials/header/social-links.html
+++ b/layouts/partials/header/social-links.html
@@ -1,10 +1,10 @@
 {{- if .Site.Params.topAppBar.social }}
 <li class="nav-item py-2 py-lg-1 col-12 col-lg-auto">
 {{- $data := dict "links" .Site.Params.topAppBar.social "OutputFormats" $.OutputFormats "home" (.GetPage "/") "params" .Site.Params "iconText" true }}
-{{- $data = merge $data (dict "class" "row" "linkClass" "col-6 col-lg-auto p-1" "iconTextClass" "ms-1 d-lg-none") }}
+{{- $data = merge $data (dict "class" "flex-row" "linkClass" "col-6 col-lg-auto p-1" "iconTextClass" "ms-1 d-lg-none") }}
 {{- partial "helpers/social-links" $data }}
 </li>
-<li class="nav-item py-2 py-lg-1 col-12 col-lg-auto ms-lg-2">
+<li class="nav-item py-2 py-lg-1 col-12 col-lg-auto">
   <div class="vr d-none d-lg-flex h-100 mx-lg-2 text-white"></div>
   <hr class="d-lg-none my-2">
 </li>


### PR DESCRIPTION
fix: Fixes the broken social links navigation under 1200px device width. The nav element was wider than the parent li element.