### PR TITLE
Add Advanced Search Options

### DIFF
--- a/assets/main/scss/_search.scss
+++ b/assets/main/scss/_search.scss
@@ -6,8 +6,9 @@
   margin: 1rem 0 1.5rem;
 
   a {
-    color: inherit;
-    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/assets/search/languages.ts
+++ b/assets/search/languages.ts
@@ -1,0 +1,16 @@
+class Languages {
+    ele: HTMLSelectElement;
+    
+    constructor(callback) {
+        this.ele = document.querySelector('#languages-select');
+        this.ele.addEventListener('change', () => {
+            callback();
+        });
+    }
+
+    getValue() {
+        return this.ele.value;
+    }
+}
+
+export default Languages;

--- a/assets/search/templates/result.html
+++ b/assets/search/templates/result.html
@@ -1,45 +1,43 @@
-<div class="search-result row card component" id="{{id}}">
-    <div class="card-header">
-        <h2 class="card-title search-result-title fs-4 my-2 text-surface">
-        <a "href="{{permalink}}">{{title}}</a>
-        </h2>
-    </div>
+<div class="search-result col-12 border-bottom pb-3 mb-3" id="{{id}}">
     <div class="card-body">
-        <div class="post-meta mb-3">
+        <h2 class="card-title search-result-title fs-4 mt-2 mb-1 text-surface"><a href="{{permalink}}">{{title}}</a></h2>
+        <p class="text-success user-select-all mb-1 text-nowrap overflow-hidden text-truncate">{{permalink}}</p>
+        <div class="post-meta mb-2">
         <span class="post-date">{{date}}</span>
-        {{- $baseURL := absLangURL "" -}}
-        {{- $placeholder := "{{#url}}{{.}}{{/url}}" -}}
-        {{- range slice "authors" "series" "categories" "tags" -}}
-        {{- printf "{{#%s}}" . }}
-        <a {{ printf "href=\"%s%s/%s/\"" $baseURL . $placeholder | safeHTMLAttr }}
-            class="btn btn-sm btn-secondary mb-1 me-2 py-0 pe-1 post-taxonomy">
-            {{- if eq . "authors" }}
-            <i class="fas fa-fw fa-user me-1"></i>d
-            {{- else if eq . "series" }}
-            <i class="fas fa-fw fa-columns me-1"></i>
-            {{- else if eq . "categories" }}
-            <i class="fas fa-fw fa-folder me-1"></i>
-            {{- end }}
-            {{- printf "{{.}}" }}
-        </a>
-        {{ printf "{{/%s}}" . }}
-        {{- end -}}
+        {{#authors}}
+            <a href="{{url}}" class="btn btn-sm btn-secondary mb-1 me-2 py-0 pe-1 post-taxonomy">
+                <i class="fas fa-fw fa-user me-1"></i>{{title}}
+            </a>
+        {{/authors}}
+        {{#categories}}
+            <a href="{{url}}" class="btn btn-sm btn-secondary mb-1 me-2 py-0 pe-1 post-taxonomy">
+                <i class="fas fa-fw fa-folder me-1"></i>{{title}}
+            </a>
+        {{/categories}}
+        {{#series}}
+            <a href="{{url}}" class="btn btn-sm btn-secondary mb-1 me-2 py-0 pe-1 post-taxonomy">
+                <i class="fas fa-fw fa-columns me-1"></i>{{title}}
+            </a>
+        {{/series}}
+        {{#tags}}
+            <a href="{{url}}" class="btn btn-sm btn-secondary mb-1 me-2 py-0 pe-1 post-taxonomy">{{title}}</a>
+        {{/tags}}
         </div>
-        <div class="search-result-content mb-3">
-        {{- print "{{#img}}" -}}
-        {{- print "{{#smallImg}}" -}}
-        <picture>
-            <source {{ print "srcset=\"{{{largeImg}}}\"" | safeHTMLAttr }} media="(max-width: 576px)">
-            <img class="img-fluid" alt="{{ print "{{{title}}}" }}" {{ print "src=\"{{{smallImg}}}\"" | safeHTMLAttr }} {{ print "data-src=\"{{{img}}}\"" | safeHTMLAttr }} loading="lazy"/>
-        </picture>
-        {{- print "{{/smallImg}}" -}}
-        {{- print "{{^smallImg}}" -}}
-        <picture>
-            <img class="img-fluid" alt="{{ print "{{{title}}}" }}" {{ print "src=\"{{{img}}}\"" | safeHTMLAttr }} loading="lazy"/>
-        </picture>
-        {{- print "{{/smallImg}}" -}}
-        {{- print "{{/img}}" -}}
-        {{ print "{{{content}}}" }}
+        <div class="search-result-content mb-2">
+        {{#img}}
+            {{#smallImg}}
+            <picture>
+                <source srcset="{{{largeImg}}}" media="(max-width: 576px)">
+                <img class="img-fluid" alt="{{title}}" src="{{{smallImg}}}" data-src="{{{img}}}" loading="lazy"/>
+            </picture>
+            {{/smallImg}}
+            {{^smallImg}}
+            <picture>
+                <img class="img-fluid" alt="{{title}}"src="{{{img}}}" loading="lazy"/>
+            </picture>
+            {{/smallImg}}
+        {{/img}}
+        {{{content}}}
         </div>
     </div>
 </div>

--- a/assets/search/templates/result.html
+++ b/assets/search/templates/result.html
@@ -1,0 +1,45 @@
+<div class="search-result row card component" id="{{id}}">
+    <div class="card-header">
+        <h2 class="card-title search-result-title fs-4 my-2 text-surface">
+        <a "href="{{permalink}}">{{title}}</a>
+        </h2>
+    </div>
+    <div class="card-body">
+        <div class="post-meta mb-3">
+        <span class="post-date">{{date}}</span>
+        {{- $baseURL := absLangURL "" -}}
+        {{- $placeholder := "{{#url}}{{.}}{{/url}}" -}}
+        {{- range slice "authors" "series" "categories" "tags" -}}
+        {{- printf "{{#%s}}" . }}
+        <a {{ printf "href=\"%s%s/%s/\"" $baseURL . $placeholder | safeHTMLAttr }}
+            class="btn btn-sm btn-secondary mb-1 me-2 py-0 pe-1 post-taxonomy">
+            {{- if eq . "authors" }}
+            <i class="fas fa-fw fa-user me-1"></i>d
+            {{- else if eq . "series" }}
+            <i class="fas fa-fw fa-columns me-1"></i>
+            {{- else if eq . "categories" }}
+            <i class="fas fa-fw fa-folder me-1"></i>
+            {{- end }}
+            {{- printf "{{.}}" }}
+        </a>
+        {{ printf "{{/%s}}" . }}
+        {{- end -}}
+        </div>
+        <div class="search-result-content mb-3">
+        {{- print "{{#img}}" -}}
+        {{- print "{{#smallImg}}" -}}
+        <picture>
+            <source {{ print "srcset=\"{{{largeImg}}}\"" | safeHTMLAttr }} media="(max-width: 576px)">
+            <img class="img-fluid" alt="{{ print "{{{title}}}" }}" {{ print "src=\"{{{smallImg}}}\"" | safeHTMLAttr }} {{ print "data-src=\"{{{img}}}\"" | safeHTMLAttr }} loading="lazy"/>
+        </picture>
+        {{- print "{{/smallImg}}" -}}
+        {{- print "{{^smallImg}}" -}}
+        <picture>
+            <img class="img-fluid" alt="{{ print "{{{title}}}" }}" {{ print "src=\"{{{img}}}\"" | safeHTMLAttr }} loading="lazy"/>
+        </picture>
+        {{- print "{{/smallImg}}" -}}
+        {{- print "{{/img}}" -}}
+        {{ print "{{{content}}}" }}
+        </div>
+    </div>
+</div>

--- a/assets/search/templates/result.html
+++ b/assets/search/templates/result.html
@@ -23,7 +23,7 @@
             <a href="{{url}}" class="btn btn-sm btn-secondary mb-1 me-2 py-0 pe-1 post-taxonomy">{{title}}</a>
         {{/tags}}
         </div>
-        <div class="search-result-content mb-2">
+        <div class="search-result-content text-surface-secondary mb-2">
         {{#img}}
             {{#smallImg}}
             <picture>

--- a/exampleSite/content/docs/advanced/hooks/index.md
+++ b/exampleSite/content/docs/advanced/hooks/index.md
@@ -32,30 +32,32 @@ In this article, we will introduce all hooks and provide some use cases.
 
 ## Overview
 
-| Hook | Description |
-|---|---|
-| `head-end` | Before the `<head>` end |
-| `body-end` | Before the `<body>` end |
-| `main-begin` | Above of the `<main>` |
-| `main-end` | Follow the `<main>` |
-| `list-begin` | Above of the posts list |
-| `list-end` | Follow the posts list |
-| `sidebar-begin` | At very top of the sidebar |
-| `sidebar-end` | Before the sidebar end |
-| `content-begin` | Above of the post content |
-| `content-end` | Follow the post content |
-| `comments-begin` | Above of the comments |
-| `comments-end` | Follow the comments |
-| `footer-begin` | At very top of the footer |
-| `footer-end` | Before the footer end |
-| `post-panel-begin` | At very top of the post panel |
-| `post-panel-end` | Before the post panel end |
-| `docs/sidebar-begin` | At very top of the `docs` sidebar |
-| `docs/sidebar-end` | Before the `docs` sidebar end |
-| `docs/nav-begin` | At very top of the navigation |
-| `docs/nav-end` | Before the navigation end |
+| Hook                       | Description                           |
+| -------------------------- | ------------------------------------- |
+| `head-end`                 | Before the `<head>` end               |
+| `body-end`                 | Before the `<body>` end               |
+| `main-begin`               | Above of the `<main>`                 |
+| `main-end`                 | Follow the `<main>`                   |
+| `list-begin`               | Above of the posts list               |
+| `list-end`                 | Follow the posts list                 |
+| `sidebar-begin`            | At very top of the sidebar            |
+| `sidebar-end`              | Before the sidebar end                |
+| `content-begin`            | Above of the post content             |
+| `content-end`              | Follow the post content               |
+| `comments-begin`           | Above of the comments                 |
+| `comments-end`             | Follow the comments                   |
+| `footer-begin`             | At very top of the footer             |
+| `footer-end`               | Before the footer end                 |
+| `post-panel-begin`         | At very top of the post panel         |
+| `post-panel-end`           | Before the post panel end             |
+| `docs/sidebar-begin`       | At very top of the `docs` sidebar     |
+| `docs/sidebar-end`         | Before the `docs` sidebar end         |
+| `docs/nav-begin`           | At very top of the navigation         |
+| `docs/nav-end`             | Before the navigation end             |
 | `contact/form-field-begin` | At very top of the contact form field |
-| `contact/form-field-end` | Before the contact form field end |
+| `contact/form-field-end`   | Before the contact form field end     |
+| `search/sidebar-begin`     | At very top of the `search` sidebar   |
+| `search/sidebar-end`       | Before the `search` sidebar end       |
 
 ## Usages
 

--- a/exampleSite/content/docs/advanced/hooks/index.zh-hans.md
+++ b/exampleSite/content/docs/advanced/hooks/index.zh-hans.md
@@ -32,30 +32,32 @@ authors = ["RazonYang"]
 
 ## 总览
 
-| 钩子 | 描述 |
-|---|---|
-| `head-end` | `<head>` 结束之前 |
-| `body-end` | `<body>` 结束之前 |
-| `main-begin` | `<main>` 上方 |
-| `main-end` | `<main>` 下方 |
-| `list-begin` | 文章列表上方 |
-| `list-end` | 文章列表下方 |
-| `sidebar-begin` | 侧边栏上方 |
-| `sidebar-end` | 侧边栏下方 |
-| `content-begin` | 文章内容上方 |
-| `content-end` | 文章内容下方 |
-| `comments-begin` | 评论上方 |
-| `comments-end` | 评论下方 |
-| `footer-begin` | `footer` 上方 |
-| `footer-end` | `footer` 下方 |
-| `post-panel-begin` | 文章工具栏上方 |
-| `post-panel-end` | 文章工具栏下方 |
-| `docs/sidebar-begin` | 文档侧边栏上方 |
-| `docs/sidebar-end` | 文档侧边栏下方 |
-| `docs/nav-begin` | 文档导航上方 |
-| `docs/nav-end` | 文档导航下方 |
-| `contact/form-field-begin` | 表单字段上方 |
-| `contact/form-field-end` | 表单字段下方 |
+| 钩子                       | 描述                                |
+| -------------------------- | ----------------------------------- |
+| `head-end`                 | `<head>` 结束之前                   |
+| `body-end`                 | `<body>` 结束之前                   |
+| `main-begin`               | `<main>` 上方                       |
+| `main-end`                 | `<main>` 下方                       |
+| `list-begin`               | 文章列表上方                        |
+| `list-end`                 | 文章列表下方                        |
+| `sidebar-begin`            | 侧边栏上方                          |
+| `sidebar-end`              | 侧边栏下方                          |
+| `content-begin`            | 文章内容上方                        |
+| `content-end`              | 文章内容下方                        |
+| `comments-begin`           | 评论上方                            |
+| `comments-end`             | 评论下方                            |
+| `footer-begin`             | `footer` 上方                       |
+| `footer-end`               | `footer` 下方                       |
+| `post-panel-begin`         | 文章工具栏上方                      |
+| `post-panel-end`           | 文章工具栏下方                      |
+| `docs/sidebar-begin`       | 文档侧边栏上方                      |
+| `docs/sidebar-end`         | 文档侧边栏下方                      |
+| `docs/nav-begin`           | 文档导航上方                        |
+| `docs/nav-end`             | 文档导航下方                        |
+| `contact/form-field-begin` | 表单字段上方                        |
+| `contact/form-field-end`   | 表单字段下方                        |
+| `search/sidebar-begin`     | At very top of the `search` sidebar |
+| `search/sidebar-end`       | Before the `search` sidebar end     |
 
 ## 用法
 

--- a/exampleSite/content/docs/advanced/hooks/index.zh-hant.md
+++ b/exampleSite/content/docs/advanced/hooks/index.zh-hant.md
@@ -32,30 +32,32 @@ authors = ["RazonYang"]
 
 ## 總覽
 
-| 鉤子 | 描述 |
-|---|---|
-| `head-end` | `<head>` 結束之前 |
-| `body-end` | `<body>` 結束之前 |
-| `main-begin` | `<main>` 上方 |
-| `main-end` | `<main>` 下方 |
-| `list-begin` | 文章列表上方 |
-| `list-end` | 文章列表上方 |
-| `sidebar-begin` | 側邊欄上方 |
-| `sidebar-end` | 側邊欄下方 |
-| `content-begin` | 文章內容上方 |
-| `content-end` | 文章內容下方 |
-| `comments-begin` | 評論上方 |
-| `comments-end` | 評論下方 |
-| `footer-begin` | `footer` 上方 |
-| `footer-end` | `footer` 下方 |
-| `post-panel-begin` | 文章工具欄上方 |
-| `post-panel-end` | 文章工具欄下方 |
-| `docs/sidebar-begin` | 文檔側邊欄上方 |
-| `docs/sidebar-end` | 文檔側邊欄上方 |
-| `docs/nav-begin` | 文檔導航上方 |
-| `docs/nav-end` | 文檔導航下方 |
-| `contact/form-field-begin` | 表單字段上方 |
-| `contact/form-field-end` | 表單字段下方 |
+| 鉤子                       | 描述                                |
+| -------------------------- | ----------------------------------- |
+| `head-end`                 | `<head>` 結束之前                   |
+| `body-end`                 | `<body>` 結束之前                   |
+| `main-begin`               | `<main>` 上方                       |
+| `main-end`                 | `<main>` 下方                       |
+| `list-begin`               | 文章列表上方                        |
+| `list-end`                 | 文章列表上方                        |
+| `sidebar-begin`            | 側邊欄上方                          |
+| `sidebar-end`              | 側邊欄下方                          |
+| `content-begin`            | 文章內容上方                        |
+| `content-end`              | 文章內容下方                        |
+| `comments-begin`           | 評論上方                            |
+| `comments-end`             | 評論下方                            |
+| `footer-begin`             | `footer` 上方                       |
+| `footer-end`               | `footer` 下方                       |
+| `post-panel-begin`         | 文章工具欄上方                      |
+| `post-panel-end`           | 文章工具欄下方                      |
+| `docs/sidebar-begin`       | 文檔側邊欄上方                      |
+| `docs/sidebar-end`         | 文檔側邊欄上方                      |
+| `docs/nav-begin`           | 文檔導航上方                        |
+| `docs/nav-end`             | 文檔導航下方                        |
+| `contact/form-field-begin` | 表單字段上方                        |
+| `contact/form-field-end`   | 表單字段下方                        |
+| `search/sidebar-begin`     | At very top of the `search` sidebar |
+| `search/sidebar-end`       | Before the `search` sidebar end     |
 
 ## 用法
 

--- a/exampleSite/layouts/partials/hooks/search/sidebar-end.html
+++ b/exampleSite/layouts/partials/hooks/search/sidebar-end.html
@@ -1,0 +1,1 @@
+{{- partial "sidebar/profile" . }}

--- a/exampleSite/layouts/partials/hooks/sidebar-begin.html
+++ b/exampleSite/layouts/partials/hooks/sidebar-begin.html
@@ -1,0 +1,1 @@
+{{- partial "sidebar/search-form" . }}

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -197,6 +197,9 @@ other = "Repository"
 [search]
 other = "Search"
 
+[search_advanced]
+other = "Advanced"
+
 [search_missing_keywords]
 other = "Please enter search keywords"
 

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -187,6 +187,9 @@ other = "仓库"
 [search]
 other = "搜索"
 
+[search_advanced]
+other = "高级"
+
 [search_missing_keywords]
 other = "请输入搜索关键词"
 

--- a/i18n/zh-hans.toml
+++ b/i18n/zh-hans.toml
@@ -187,6 +187,9 @@ other = "仓库"
 [search]
 other = "搜索"
 
+[search_advanced]
+other = "高级"
+
 [search_missing_keywords]
 other = "请输入搜索关键词"
 

--- a/i18n/zh-hant.toml
+++ b/i18n/zh-hant.toml
@@ -187,6 +187,9 @@ other = "倉庫"
 [search]
 other = "搜尋"
 
+[search_advanced]
+other = "高級"
+
 [search_missing_keywords]
 other = "請輸入搜尋關鍵詞"
 

--- a/i18n/zh-hk.toml
+++ b/i18n/zh-hk.toml
@@ -187,6 +187,9 @@ other = "倉庫"
 [search]
 other = "搜索"
 
+[search_advanced]
+other = "高級"
+
 [search_missing_keywords]
 other = "請輸入搜索關鍵詞"
 

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -187,6 +187,9 @@ other = "倉庫"
 [search]
 other = "搜尋"
 
+[search_advanced]
+other = "高級"
+
 [search_missing_keywords]
 other = "請輸入搜尋關鍵詞"
 

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,29 +1,24 @@
 {{ define "content" }}
 <div class="search container">
   <div class="row">
-    <div class="d-flex col-12 col-lg-8">
+    <div class="d-flex col-12 col-lg-8 component py-3 pt-4 px-2 rounded">
       {{- $logo := (default "images/logo.webp" .Site.Params.logo) }}
       {{- if $logo }}
       <div class="flex-shrink-0 d-none d-md-block">
-        <img src="{{ $logo | absURL }}" width="80px" height="80px">
+        <img class="position-sticky" src="{{ $logo | absURL }}" width="80px" height="80px" style="top: 84px">
       </div>
       {{- end -}}
-      <div class="{{ if $logo }}flex-grow-1 ms-0 ms-md-3{{ end }} container px-0">
-        <form id="searchForm" class="col-12 search-form mb-3 p-0">
-          <div class="input-group input-group-lg align-items-center">
-            <span class="btn btn-search disabled position-absolute left-0 border-0" type="submit" aria-label="submit">
-              <i class="fas fa-fw fa-search text-primary"></i>
-            </span>
-            <input class="form-control rounded ps-5 border-primary" name="q" type="search" aria-label="Search">
-          </div>
-        </form>
-        <div class="search-stat mb-3 p-0 col-12">
+      <div class="{{ if $logo }}flex-grow-1 ms-0 ms-md-3{{ end }} container">
+        {{- partial "search/form" . }}
+        <div class="text-center my-2">
           <div id="loadingSpinner" class="spinner-border text-primary" role="status">
             <span class="visually-hidden">Loading...</span>
           </div>
+        </div>
+        <div class="search-stat mb-3 col-12">
           <span id="searchStat"></span>
         </div>
-        <div id="searchResults" class="search-results mb-3 p-0 row"></div>
+        <div id="searchResults" class="search-results mb-3 row"></div>
         <div class="text-center mb-3">
           <button class="btn btn-block btn-outline-primary d-none" type="button" id="btnLoadMore">{{ i18n "load_more" }}</button>
         </div>

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
 <div class="search container">
   <div class="row">
-    <div class="d-flex">
+    <div class="d-flex col-12 col-lg-8">
       {{- $logo := (default "images/logo.webp" .Site.Params.logo) }}
       {{- if $logo }}
       <div class="flex-shrink-0 d-none d-md-block">
@@ -28,6 +28,9 @@
           <button class="btn btn-block btn-outline-primary d-none" type="button" id="btnLoadMore">{{ i18n "load_more" }}</button>
         </div>
       </div>
+    </div>
+    <div class="col-lg-4 d-none d-lg-block">
+      {{- partial "search/sidebar" . }}
     </div>
   </div>
 </div>

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,26 +1,34 @@
 {{ define "content" }}
 <div class="search container">
-  <div class="container">
-    <div class="row">
-      <form id="searchForm" class="search-form mb-3 p-0">
-        <div class="input-group input-group-lg align-items-center">
-          <span class="btn btn-search disabled position-absolute left-0 border-0" type="submit" aria-label="submit">
-            <i class="fas fa-fw fa-search text-primary"></i>
-          </span>
-          <input class="form-control rounded ps-5" name="q" type="search" aria-label="Search">
+  <div class="row">
+    <div class="d-flex">
+      {{- $logo := (default "images/logo.webp" .Site.Params.logo) }}
+      {{- if $logo }}
+      <div class="flex-shrink-0 d-none d-md-block">
+        <img src="{{ $logo | absURL }}" width="80px" height="80px">
+      </div>
+      {{- end -}}
+      <div class="{{ if $logo }}flex-grow-1 ms-0 ms-md-3{{ end }} container px-0">
+        <form id="searchForm" class="col-12 search-form mb-3 p-0">
+          <div class="input-group input-group-lg align-items-center">
+            <span class="btn btn-search disabled position-absolute left-0 border-0" type="submit" aria-label="submit">
+              <i class="fas fa-fw fa-search text-primary"></i>
+            </span>
+            <input class="form-control rounded ps-5 border-primary" name="q" type="search" aria-label="Search">
+          </div>
+        </form>
+        <div class="search-stat mb-3 p-0 col-12">
+          <div id="loadingSpinner" class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Loading...</span>
+          </div>
+          <span id="searchStat"></span>
         </div>
-      </form>
-      <div class="search-stat mb-3 p-0">
-        <div id="loadingSpinner" class="spinner-border text-primary" role="status">
-          <span class="visually-hidden">Loading...</span>
+        <div id="searchResults" class="search-results mb-3 p-0 row"></div>
+        <div class="text-center mb-3">
+          <button class="btn btn-block btn-outline-primary d-none" type="button" id="btnLoadMore">{{ i18n "load_more" }}</button>
         </div>
-        <span id="searchStat"></span>
       </div>
     </div>
-  </div>
-  <div id="searchResults" class="search-results container mb-3"></div>
-  <div class="text-center mb-3">
-    <button class="btn btn-block btn-outline-primary d-none" type="button" id="btnLoadMore">{{ i18n "load_more" }}</button>
   </div>
 </div>
 <script type="text/html" id="templateResult">

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -24,51 +24,7 @@
   </div>
 </div>
 <script type="text/html" id="templateResult">
-  <div class="search-result row card component" id="{{ print "{{id}}" }}">
-    <div class="card-header">
-      <h2 class="card-title search-result-title fs-4 my-2 text-surface">
-        <a {{ printf "href={{permalink}}" | safeHTMLAttr }}>{{ print "{{title}}" }}</a>
-      </h2>
-    </div>
-    <div class="card-body">
-      <div class="post-meta mb-3">
-        <span class="post-date">{{ printf "{{date}}" }}</span>
-        {{- $baseURL := absLangURL "" -}}
-        {{- $placeholder := "{{#url}}{{.}}{{/url}}" -}}
-        {{- range slice "authors" "series" "categories" "tags" -}}
-        {{- printf "{{#%s}}" . }}
-        <a {{ printf "href=\"%s%s/%s/\"" $baseURL . $placeholder | safeHTMLAttr }}
-          class="btn btn-sm btn-secondary mb-1 me-2 py-0 pe-1 post-taxonomy">
-          {{- if eq . "authors" }}
-            <i class="fas fa-fw fa-user me-1"></i>
-          {{- else if eq . "series" }}
-            <i class="fas fa-fw fa-columns me-1"></i>
-          {{- else if eq . "categories" }}
-            <i class="fas fa-fw fa-folder me-1"></i>
-          {{- end }}
-          {{- printf "{{.}}" }}
-        </a>
-        {{ printf "{{/%s}}" . }}
-        {{- end -}}
-      </div>
-      <div class="search-result-content mb-3">
-        {{- print "{{#img}}" -}}
-        {{- print "{{#smallImg}}" -}}
-        <picture>
-          <source {{ print "srcset=\"{{{largeImg}}}\"" | safeHTMLAttr }} media="(max-width: 576px)">
-          <img class="img-fluid" alt="{{ print "{{{title}}}" }}" {{ print "src=\"{{{smallImg}}}\"" | safeHTMLAttr }} {{ print "data-src=\"{{{img}}}\"" | safeHTMLAttr }} loading="lazy"/>
-        </picture>
-        {{- print "{{/smallImg}}" -}}
-        {{- print "{{^smallImg}}" -}}
-        <picture>
-          <img class="img-fluid" alt="{{ print "{{{title}}}" }}" {{ print "src=\"{{{img}}}\"" | safeHTMLAttr }} loading="lazy"/>
-        </picture>
-        {{- print "{{/smallImg}}" -}}
-        {{- print "{{/img}}" -}}
-        {{ print "{{{content}}}" }}
-      </div>
-    </div>
-  </div>
+  {{ (resources.Get "search/templates/result.html").Content | safeHTML }}
 </script>
 <script type="text/html" id="templateMissingKeywords">
   {{ i18n "search_missing_keywords" }}

--- a/layouts/partials/search/form.html
+++ b/layouts/partials/search/form.html
@@ -1,0 +1,41 @@
+<form id="searchForm" class="col-12 search-form mb-3" novalidate>
+    <div class="input-group input-group-lg align-items-center">
+        <input class="form-control rounded border-primary pe-5" name="q" type="search" aria-label="Search">
+        <button class="btn btn-sm btn-search position-absolute end-0 border-0 border-start border-secondary p-2" type="submit">
+            <i class="fas fa-fw fa-search text-primary"></i>
+        </button>
+    </div>
+    <p class="text-end mt-1">
+        <a class="" data-bs-toggle="collapse" href="#advanced-search" role="button" aria-expanded="false" aria-controls="advanced-search">
+          {{- i18n "search_advanced" -}}
+        </a>
+    </p>
+    <div class="row g-1 collapse" id="advanced-search">
+        <select class="form-select col-12 mb-2" aria-label="Language" name="lang" id="languages-select">
+            <option selected value="">{{ i18n "language" }}</option>
+            {{- range .Site.Languages -}}
+            <option value="{{ .Lang }}">{{ .LanguageName }}</option>
+            {{- end }}
+        </select>
+        <div class="form-floating col-6 col-lg-3">
+            <input type="text" class="form-control form-control-sm" name="author" id="author-input" list="authors-list" placeholder="{{ i18n "authors" }}">
+            <label for="author-input">{{ i18n "authors" }}</label>
+            <datalist id="authors-list"></datalist>
+        </div>
+        <div class="form-floating col-6 col-lg-3">
+            <input type="text" class="form-control form-control-sm" name="category" id="category-input" list="categories-list" placeholder="{{ i18n "categories" }}">
+            <label for="category-input">{{ i18n "categories" }}</label>
+            <datalist id="categories-list"></datalist>
+        </div>
+        <div class="form-floating col-6 col-lg-3">
+            <input type="text" class="form-control form-control-sm" name="series" id="series-input" list="series-list" placeholder="{{ i18n "series" }}">
+            <label for="series-input">{{ i18n "series" }}</label>
+            <datalist id="series-list"></datalist>
+        </div>
+        <div class="form-floating col-6 col-lg-3">
+            <input type="text" class="form-control form-control-sm" name="tag" id="tag-input" list="tags-list" placeholder="{{ i18n "tags" }}">
+            <label for="tag-input">{{ i18n "tags" }}</label>
+            <datalist id="tags-list"></datalist>
+        </div>
+    </div>
+</form>

--- a/layouts/partials/search/index.json
+++ b/layouts/partials/search/index.json
@@ -1,6 +1,7 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range .Site.RegularPages -}}
-    {{- $date := .Date.Format $.Site.Params.dateFormat -}}
+    {{- $page := . }}
+    {{- $date := .Date | time.Format ":date_long" -}}
     {{- $title := .Title }}
     {{- if $.Site.Params.titleCase -}}
         {{- $title = title $title -}}
@@ -22,7 +23,22 @@
         {{- $img = $featured.Permalink -}}
       {{- end -}}
     {{- end -}}
-    {{- $item := (dict "title" $title "authors" .Params.authors "tags" .Params.tags "categories" .Params.categories "series" .Params.series "content" .Plain "permalink" .Permalink "date" $date "img" $img "smallImg" $smallImg "largeImg" $largeImg) -}}
+    {{- $item := (dict 
+      "title" $title 
+      "content" .Plain 
+      "permalink" .Permalink 
+      "date" $date 
+      "img" $img 
+      "smallImg" $smallImg
+      "largeImg" $largeImg
+    ) -}}
+    {{- range $taxonomyName, $value := $.Site.Taxonomies }}
+      {{- $terms := slice }}
+      {{- range $page.GetTerms $taxonomyName }}
+        {{- $terms = $terms | append (dict "title" .Title "url" .Permalink) }}
+      {{- end }}
+      {{- $item = merge $item (dict $taxonomyName $terms) }}
+    {{- end }}
     {{- $.Scratch.Add "index" $item -}}
 {{- end -}}
 {{- $.Scratch.Get "index" | uniq | jsonify -}}

--- a/layouts/partials/search/index.json
+++ b/layouts/partials/search/index.json
@@ -1,5 +1,9 @@
-{{- $.Scratch.Add "index" slice -}}
-{{- range .Site.RegularPages -}}
+{{- $.Scratch.Add "pages" slice -}}
+{{- $.Scratch.Add "authors" slice }}
+{{- $.Scratch.Add "categories" slice }}
+{{- $.Scratch.Add "series" slice }}
+{{- $.Scratch.Add "tags" slice }}
+{{- range where .Site.AllPages "Kind" "page" -}}
     {{- $page := . }}
     {{- $date := .Date | time.Format ":date_long" -}}
     {{- $title := .Title }}
@@ -24,6 +28,7 @@
       {{- end -}}
     {{- end -}}
     {{- $item := (dict 
+      "lang" .Language.Lang
       "title" $title 
       "content" .Plain 
       "permalink" .Permalink 
@@ -36,9 +41,17 @@
       {{- $terms := slice }}
       {{- range $page.GetTerms $taxonomyName }}
         {{- $terms = $terms | append (dict "title" .Title "url" .Permalink) }}
+        {{- $.Scratch.Add ($taxonomyName | pluralize) (slice .Title) }}
       {{- end }}
       {{- $item = merge $item (dict $taxonomyName $terms) }}
     {{- end }}
-    {{- $.Scratch.Add "index" $item -}}
+    {{- $.Scratch.Add "pages" (slice $item) }}
 {{- end -}}
-{{- $.Scratch.Get "index" | uniq | jsonify -}}
+{{- dict
+  "pages" ($.Scratch.Get "pages")
+  "authors" ($.Scratch.Get "authors"| uniq)
+  "categories" ($.Scratch.Get "categories"| uniq)
+  "series" ($.Scratch.Get "series" | uniq)
+  "tags" ($.Scratch.Get "tags"| uniq)
+ | jsonify 
+-}}

--- a/layouts/partials/search/sidebar.html
+++ b/layouts/partials/search/sidebar.html
@@ -1,0 +1,4 @@
+<div class="search-sidebar position-sticky px-2" style="top: 84px">
+    {{- partial "hooks/search/sidebar-begin" . }}
+    {{- partial "hooks/search/sidebar-end" . }}
+</div>

--- a/layouts/partials/sidebar/search-form.html
+++ b/layouts/partials/sidebar/search-form.html
@@ -1,0 +1,15 @@
+{{- $page := .Site.GetPage "search" -}}
+{{- if $page }}
+<div class="row component card">
+    <div class="card-body">
+        <form action="{{ $page.Permalink }}">
+            <div class="input-group">
+                <input name="q" class="form-control" placeholder="{{ i18n "search" }}">
+                <button class="btn btn-sm btn-search position-absolute end-0 border-0 border-start border-secondary p-2" type="submit">
+                    <i class="fas fa-fw fa-search text-primary"></i>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{{- end }}

--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -35,7 +35,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
     // deep: [/blue$/],
     greedy: [/carousel-indicators$/]
   },
-  dynamicAttributes: ['data-bs-popper', 'data-theme', 'data-palette', 'role']
+  dynamicAttributes: ['data-bs-popper', 'data-theme', 'data-palette', 'role', 'placeholder-shown']
 });
 
 exports.default = purgecss;


### PR DESCRIPTION
1. Allow searching all pages regardless of their languages.
2. Allow filtering result by language, author, category, tag and series.
3. Add search sidebar and some hooks: `search/sidebar-begin` and `search/sidebar-end`.
4. Redesign the search page UI.
5. Add the search form widget.