### PR TITLE
feat(search): allow filtering results via taxonomies with AND, OR operations

### DIFF
--- a/assets/search/engine.ts
+++ b/assets/search/engine.ts
@@ -12,10 +12,10 @@ class Engine {
         'title',
         'content',
         'lang',
-        'authors.title',
-        'categories.title',
-        'series.title',
-        'tags.title',
+        'authors_titles',
+        'categories_titles',
+        'series_titles',
+        'tags_titles',
       ],
     });
     fetch(window.searchIndex).then((response)=>{
@@ -84,19 +84,19 @@ class Engine {
         };
         const author = data.get('author');
         if (author) {
-          params.$and.push({ 'authors.title': author });
+          params.$and.push({ 'authors_titles': author });
         }
         const category = data.get('category');
         if (category) {
-          params.$and.push({ 'categories.title': category });
+          params.$and.push({ 'categories_titles': category });
         }
         const series = data.get('series');
         if (series) {
-          params.$and.push({ 'series.title': series });
+          params.$and.push({ 'series_titles': series });
         }
         const tag = data.get('tag');
         if (tag) {
-          params.$and.push({ 'tags.title': tag });
+          params.$and.push({ 'tags_titles': tag });
         }
         const lang = data.get('lang');
         if (lang) {

--- a/layouts/partials/search/index.json
+++ b/layouts/partials/search/index.json
@@ -41,11 +41,16 @@
     ) -}}
     {{- range $taxonomyName, $value := $.Site.Taxonomies }}
       {{- $terms := slice }}
+      {{- $termTitles := slice }}
       {{- range $page.GetTerms $taxonomyName }}
         {{- $terms = $terms | append (dict "title" .Title "url" .Permalink) }}
+        {{- $termTitles = $termTitles | append .Title }}
         {{- $.Scratch.Add ($taxonomyName | pluralize) (slice .Title) }}
       {{- end }}
-      {{- $item = merge $item (dict $taxonomyName $terms) }}
+      {{- $item = merge $item (dict
+          $taxonomyName $terms
+          (printf "%s_titles" $taxonomyName) (delimit $termTitles " ")
+      )}}
     {{- end }}
     {{- $.Scratch.Add "pages" (slice $item) }}
 {{- end -}}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17720932/186832688-e2e17d1d-11a4-4cbf-b32e-762a11132111.png)
For example: tag `'CSS 'HTML | 'Alert` matches tags that start with `CSS` and `HTML`, OR start with `Alert`.
See also [extended search](https://fusejs.io/examples.html#extended-search).