### PR TITLE
UX: display TOC above content on small screens and DO NOT collapse sidebar widgets by default.

### DIFF
--- a/assets/js/toc/index.ts
+++ b/assets/js/toc/index.ts
@@ -1,0 +1,22 @@
+import Component from "js/component";
+
+export default class TOC implements Component
+{
+    private container: HTMLElement;
+    private target: HTMLElement;
+
+    constructor(container: string, target: string) {
+        this.container = document.querySelector(container);
+        this.target = document.querySelector(target);
+    }
+
+    run() {
+        if (!this.target || !this.container) {
+            return;
+        }
+        
+        const child = this.target.cloneNode(true);
+        child.removeAttribute('id');
+        this.container.appendChild(child);
+    }
+}

--- a/assets/main/js/index.ts
+++ b/assets/main/js/index.ts
@@ -1,15 +1,16 @@
 import 'bootstrap/dist/js/bootstrap.bundle';
 
-import App from 'js/app';
 import ActionsPanel from 'js/actions-panel';
+import App from 'js/app';
+import Code from 'js/code';
+import Docs from 'js/docs';
+import FontSizeSelector from 'js/font-size-selector';
+import FormValidator from 'js/form-validator';
 import LoadingBar from 'js/loading-bar';
 import Scroller from 'js/scroller';
 import SidebarToggle from 'js/sidebar-toggle';
-import FontSizeSelector from 'js/font-size-selector';
-import Code from 'js/code';
 import TableWrapper from 'js/table-wrapper';
-import Docs from 'js/docs';
-import FormValidator from 'js/form-validator';
+import TOC from 'js/toc';
 import components from './components';
 
 const app = new App();
@@ -23,8 +24,10 @@ app.attach(
   new TableWrapper(document.querySelectorAll('table')),
   new Docs(),
   new FormValidator(),
+  new TOC('#post-toc-container', '#TableOfContents'),
   ...components
 );
 app.run();
 
 import './custom';
+

--- a/assets/main/scss/post/_toc.scss
+++ b/assets/main/scss/post/_toc.scss
@@ -1,6 +1,5 @@
-#TableOfContents { /* stylelint-disable-line */
-  @extend .surface; /* stylelint-disable-line */
-
+#TableOfContents,
+#post-toc-container > nav { /* stylelint-disable-line */
   ol,
   ul {
     @if $tocStyleType {
@@ -27,4 +26,13 @@
       color: var(--#{$prefix}primary);
     }
   }
+}
+
+#TableOfContents {
+  @extend .surface; /* stylelint-disable-line */
+}
+
+#post-toc-container > nav {
+  background: var(--#{$prefix}surface-bg);
+  color: var(--#{$prefix}surface-color);
 }

--- a/exampleSite/assets/main/scss/_custom.scss
+++ b/exampleSite/assets/main/scss/_custom.scss
@@ -1,0 +1,6 @@
+.sidebar {
+    .post-toc {
+        position: sticky;
+        top: 84px;
+    }
+}

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -83,6 +83,7 @@ viewer = true # Image Viewer
   # postsToggle = false # Disable posts toggle
   # featuredPosts = true # Enable featured posts widget
   # recentPosts = true # Enable featured posts widget
+  # collapsed = true # Collapse sidebar widgets by default on small screens.
 
 [codeBlock]
   # maxLines = 8

--- a/exampleSite/content/docs/configuration/site-params/index.md
+++ b/exampleSite/content/docs/configuration/site-params/index.md
@@ -142,6 +142,7 @@ The site parameters are located in `config/_default/params.toml` by default.
 | `sidebar.postsToggle` | Boolean | `true` | Show the posts toggle on the sidebar.
 | `sidebar.featuredPosts` | Boolean | `false` | Show the featured posts widget on the sidebar.
 | `sidebar.recentPosts` | Boolean | `false` | Show the recent posts widget on the sidebar.
+| `sidebar.collapsed` | Boolean | `flase` | Collapse sidebar widgets by default on small screens.
 | **Meta Tag**
 | `metaRobots` | String | - | Empty means that turn it off.
 | `contact` | Object | - | [Contact Form]({{< ref "docs/layouts/contact" >}})

--- a/exampleSite/content/docs/configuration/site-params/index.zh-hans.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-hans.md
@@ -145,6 +145,7 @@ authors = ["RazonYang"]
 | `sidebar.postsToggle` | Boolean | `true` | Show the posts toggle on the sidebar.
 | `sidebar.featuredPosts` | Boolean | `false` | Show the featured posts widget on the sidebar.
 | `sidebar.recentPosts` | Boolean | `false` | Show the recent posts widget on the sidebar.
+| `sidebar.collapsed` | Boolean | `flase` | Collapse sidebar widgets by default on small screens.
 | **Meta Tag**
 | `metaRobots` | String | - | 空字符串表示禁用。
 | `contact` | Object | - | [联系表单]({{< ref "docs/layouts/contact" >}})

--- a/exampleSite/content/docs/configuration/site-params/index.zh-hant.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-hant.md
@@ -145,6 +145,7 @@ authors = ["RazonYang"]
 | `sidebar.postsToggle` | Boolean | `true` | Show the posts toggle on the sidebar.
 | `sidebar.featuredPosts` | Boolean | `false` | Show the featured posts widget on the sidebar.
 | `sidebar.recentPosts` | Boolean | `false` | Show the recent posts widget on the sidebar.
+| `sidebar.collapsed` | Boolean | `flase` | Collapse sidebar widgets by default on small screens.
 | **Meta Tag**
 | `metaRobots` | String | - | 空字符串表示禁用。
 | `contact` | Object | - | [聯系表單]({{< ref "docs/layouts/contact" >}})

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -8,7 +8,6 @@
 {{- $path := replace .Permalink $baseURL "" -}}
 {{- $date := split $path "/" -}}
 {{- $pages := where .Site.RegularPages "Type" "in" .Site.Params.mainSections -}}
-{{- partial "sidebar" . -}}
 <div class="col-lg-8 mb-4">
   <div class="container">
     {{- partial "breadcrumb" . -}}
@@ -21,4 +20,5 @@
     </div>
   </div>
 </div>
+{{- partial "sidebar" . -}}
 {{ end }}

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -16,4 +16,3 @@
 </div>
 {{- partial "sidebar" . -}}
 {{ end }}
-  

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -1,5 +1,4 @@
 {{ define "content" }}
-{{- partial "sidebar" . -}}
 <div class="col-lg-8">
     {{- partial "breadcrumb" . -}}
     <div class="contact row component card">
@@ -15,5 +14,6 @@
         </div>
     </div>
 </div>
+{{- partial "sidebar" . -}}
 {{ end }}
   

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,9 @@
 {{ define "content" }}
-{{- partial "sidebar" . -}}
 <div class="col-lg-8">
   <div class="container">
     {{- partial "breadcrumb" . -}}
     {{- partial "post" . -}}
   </div>
 </div>
+{{- partial "sidebar" . -}}
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,5 +1,4 @@
 {{ define "content" }}
-{{- partial "sidebar" . -}}
 <div class="col-lg-8">
   <div class="container">
     {{- partial "breadcrumb" . -}}
@@ -39,4 +38,5 @@
     {{- partial "pagination" . -}}
   </div>
 </div>
+{{- partial "sidebar" . -}}
 {{ end }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
 {{- partial "docs/nav" . -}}
-{{- partial "docs/sidebar" . -}}
 <div class="col-lg-7 ms-auto">
   {{ partial "docs/list" . }}
 </div>
+{{- partial "docs/sidebar" . -}}
 {{ end }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,10 +1,10 @@
 {{ define "content" }}
 {{- partial "docs/nav" . -}}
-{{- partial "docs/sidebar" . -}}
 <div class="col-lg-7 ms-auto">
   <div class="container-fluid">
     {{- partial "breadcrumb" . -}}
     {{- partial "docs/post" . -}}
   </div>
 </div>
+{{- partial "docs/sidebar" . -}}
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
 {{- partial "carousel" . -}}
-{{- partial "sidebar" . -}}
 <div class="col-lg-8">
   {{ partial "list" . }}
 </div>
+{{- partial "sidebar" . -}}
 {{ end }}

--- a/layouts/partials/docs/post.html
+++ b/layouts/partials/docs/post.html
@@ -7,6 +7,7 @@
     {{- partial "post/meta" . -}}
     {{- partial "post/featured-image" . -}}
     {{- partial "hooks/content-begin" . -}}
+    {{- partial "post/toc-wrapper" . -}}
     <div class="post-content mb-3" data-bs-spy="scroll" data-bs-target="#TableOfContents" tabindex="0">
     {{- .Content -}}
     </div>

--- a/layouts/partials/docs/repo.html
+++ b/layouts/partials/docs/repo.html
@@ -1,3 +1,4 @@
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 {{- with $.Site.Params.repo -}}
 {{- $url := .url -}}
 {{- $branch := default "master" .branch -}}
@@ -9,11 +10,13 @@
     <div class="accordion-item docs-repo row card component">
         <div class="card-header accordion-header" id="repo-header">
             <h2 class="card-title fs-4 my-2 text-surface d-none d-lg-block">{{ i18n "repo_title" }}</h2>
-            <a class="accordion-button d-lg-none mb-1 collapsed shadow-none p-0 bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#repo" aria-expanded="false" aria-controls="repo">
+            <a
+                class="accordion-button d-lg-none mb-1 shadow-none p-0 bg-transparent{{ if $collapsed }} collapsed{{ end }}"
+                type="button" data-bs-toggle="collapse" data-bs-target="#repo" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="repo">
                 {{ i18n "repo_title" }}
             </a>
         </div>
-        <div class="card-body collapse accordion-collapse accordion-body text-secondary-on-surface d-lg-block" id="repo" aria-labelledby="repo-header">
+        <div class="card-body collapse accordion-collapse accordion-body text-secondary-on-surface d-lg-block{{ if not $collapsed }} show{{ end }}" id="repo" aria-labelledby="repo-header">
             <ul class="list-unstyled">
                 {{- if $.File -}}
                 {{- $filePath := printf "%s%s/%s/%s" $branch $subPath $contentDir $.File.Path -}}

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -9,6 +9,8 @@
     {{- partial "hooks/content-begin" . -}}
     {{- if eq "content" .Site.Params.tocPosition -}}
       {{- partial "post/toc" . -}}
+    {{- else }}
+      {{- partial "post/toc-wrapper" . -}}
     {{- end -}}
     {{- partial "post/share" . -}}
     <div class="post-content mb-3" data-bs-spy="scroll" data-bs-target="#TableOfContents" tabindex="0">

--- a/layouts/partials/post/toc-wrapper.html
+++ b/layouts/partials/post/toc-wrapper.html
@@ -1,0 +1,4 @@
+<div id="postTOC" class="mt-2 mb-4 d-block d-lg-none">
+    <h2 class="text-surface mb-3">{{ i18n "table_of_contents" }}</h2>
+    <div id="post-toc-container"></div>
+</div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<aside class="col-lg-4 sidebar d-flex order-lg-5">
+<aside class="col-lg-4 sidebar d-flex">
   <div class="container d-flex flex-column">
     {{ partial "hooks/sidebar-begin" . }}
     {{ partial "sidebar/main" . }}

--- a/layouts/partials/sidebar/archive.html
+++ b/layouts/partials/sidebar/archive.html
@@ -2,6 +2,7 @@
 {{- $basePath := strings.TrimSuffix "/" (default "/archives" .Site.Params.archive.basePath) }}
 {{- $basePath = printf "/%s/" (strings.TrimPrefix "/" $basePath)  }}
 {{- $archivePage := $.GetPage $basePath }}
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 <div class="accordion archives">
   <section class="row card component">
       <div class="card-header">
@@ -12,11 +13,13 @@
             {{ i18n "archives" }}
             {{- end }}
         </h2>
-        <a class="accordion-button d-lg-none mb-1 collapsed shadow-none p-0 bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#archives" aria-expanded="false" aria-controls="archives">
+        <a
+          class="accordion-button d-lg-none mb-1 shadow-none p-0 bg-transparent{{ if $collapsed }} collapsed{{ end }}"
+          type="button" data-bs-toggle="collapse" data-bs-target="#archives" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="archives">
             {{ i18n "archives" }}
         </a>
       </div>
-      <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="archives">
+      <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="archives">
         {{- partial "sidebar/archive-items" . }}
       </div>
   </section>

--- a/layouts/partials/sidebar/featured-posts.html
+++ b/layouts/partials/sidebar/featured-posts.html
@@ -1,4 +1,5 @@
 {{- $count := default .Params.featuredPostCount .Site.Params.featuredPostCount }}
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 {{- if and $count (default false .Site.Params.sidebar.featuredPosts) }}
   {{- $featuredPosts := first $count (where (where site.RegularPages "Type" "in" site.Params.mainSections) ".Params.featured" "eq" true) }}
   {{- with $featuredPosts }}
@@ -6,11 +7,13 @@
     <section class="row card component">
       <div class="card-header">
         <h2 class="card-title my-2 fs-4 text-surface d-none d-lg-block">{{ i18n "featured_posts" }}</h2>
-        <a class="accordion-button d-lg-none mb-1 collapsed shadow-none p-0 bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#featured-posts" aria-expanded="false" aria-controls="featured-posts">
+        <a
+          class="accordion-button d-lg-none mb-1 shadow-none p-0 bg-transparent{{ if $collapsed }} collapsed{{ end }}"
+          type="button" data-bs-toggle="collapse" data-bs-target="#featured-posts" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="featured-posts">
             {{ i18n "featured_posts" }}
         </a>
       </div>
-      <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="featured-posts">
+      <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="featured-posts">
         <ul class="post-list list-unstyled ms-1">
         {{- range . }}
           <li class="mb-2">

--- a/layouts/partials/sidebar/posts-toggle.html
+++ b/layouts/partials/sidebar/posts-toggle.html
@@ -1,3 +1,4 @@
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 {{- if default true .Site.Params.sidebar.postsToggle }}
 {{- $recentCount := default .Params.recentPostCount .Site.Params.recentPostCount }}
 {{- $recentSections := .Site.Params.mainSections }}
@@ -19,11 +20,13 @@
 <div class="accordion posts-toggle">
     <section class="row card component accordion-item">
         <div class="accordion-header card-header border-0">
-            <a class="accordion-button d-lg-none mb-1 collapsed shadow-none p-0 bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#posts-toggle" aria-expanded="false" aria-controls="posts-toggle">
+            <a
+                class="accordion-button d-lg-none mb-1 shadow-none p-0 bg-transparent{{ if $collapsed }} collapsed{{ end }}"
+                type="button" data-bs-toggle="collapse" data-bs-target="#posts-toggle" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="posts-toggle">
                 {{ i18n "posts" }}
             </a>
         </div>
-        <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="posts-toggle">
+        <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="posts-toggle">
             <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
                 {{- if $featuredPosts }}
                 <li class="nav-item" role="presentation">

--- a/layouts/partials/sidebar/profile/compact.html
+++ b/layouts/partials/sidebar/profile/compact.html
@@ -1,11 +1,14 @@
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 <div class="accordion profile profile-compact">
   <div class="accordion-item card row component">
     <div class="accordion-header card-header border-0" id="profile-header">
-      <a class="accordion-button d-lg-none mb-2 collapsed shadow-none p-0 bg-transparent text-surface" type="button" data-bs-toggle="collapse" data-bs-target="#profile" aria-expanded="false" aria-controls="profile">
+      <a 
+        class="accordion-button d-lg-none mb-2 shadow-none p-0 bg-transparent text-surface{{ if $collapsed }} collapsed{{ end }}"
+        type="button" data-bs-toggle="collapse" data-bs-target="#profile" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="profile">
         {{ i18n "profile" }}
       </a>
     </div>
-    <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="profile" aria-labelledby="profile-header">
+    <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="profile" aria-labelledby="profile-header">
       <div class="d-flex">
         <div class="d-flex flex-shrink-0 justify-content-center align-items-center">
           {{- partial "sidebar/profile/avatar" . -}}

--- a/layouts/partials/sidebar/profile/default.html
+++ b/layouts/partials/sidebar/profile/default.html
@@ -1,11 +1,14 @@
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 <div class="accordion profile">
   <div class="accordion-item card row text-center component">
     <div class="accordion-header card-header border-0" id="profile-header">
-      <a class="accordion-button d-lg-none mb-2 collapsed shadow-none p-0 bg-transparent text-surface" type="button" data-bs-toggle="collapse" data-bs-target="#profile" aria-expanded="false" aria-controls="profile">
+      <a
+        class="accordion-button d-lg-none mb-2 shadow-none p-0 bg-transparent text-surface{{ if $collapsed }} collapsed{{ end }}"
+        type="button" data-bs-toggle="collapse" data-bs-target="#profile" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="profile">
         {{ i18n "profile" }}
       </a>
     </div>
-    <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="profile" aria-labelledby="profile-header">
+    <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="profile" aria-labelledby="profile-header">
       <div class="col-12 d-flex align-items-center justify-content-center">
         {{- partial "sidebar/profile/avatar" . -}}
       </div>

--- a/layouts/partials/sidebar/recent-posts.html
+++ b/layouts/partials/sidebar/recent-posts.html
@@ -1,3 +1,4 @@
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 {{- $count := default .Params.recentPostCount .Site.Params.recentPostCount }}
 {{- $sections := .Site.Params.mainSections }}
 {{- if in (slice "posts" "docs") .Type }}
@@ -8,11 +9,13 @@
   <section class="row card component">
     <div class="card-header">
       <h2 class="card-title my-2 fs-4 text-surface d-none d-lg-block">{{ i18n "recent_posts" }}</h2>
-      <a class="accordion-button d-lg-none mb-1 collapsed shadow-none p-0 bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#recent-posts" aria-expanded="false" aria-controls="recent-posts">
+      <a
+        class="accordion-button d-lg-none mb-1 shadow-none p-0 bg-transparent{{ if $collapsed }} collapsed{{ end }}"
+        type="button" data-bs-toggle="collapse" data-bs-target="#recent-posts" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="recent-posts">
           {{ i18n "recent_posts" }}
       </a>
     </div>
-    <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="recent-posts">
+    <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="recent-posts">
       <ul class="post-list list-unstyled ms-1">
       {{- range first $count (where site.RegularPages.ByDate.Reverse "Type" "in" $sections) }}
         <li class="mb-2">

--- a/layouts/partials/sidebar/stats.html
+++ b/layouts/partials/sidebar/stats.html
@@ -4,14 +4,17 @@
     "series" "columns"
     "categories" "folder"
 }}
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 <div class="accordion stats">
   <div class="accordion-item card row component">
     <div class="accordion-header card-header border-0" id="stats-header">
-      <a class="accordion-button d-lg-none mb-2 collapsed shadow-none p-0 bg-transparent text-surface" type="button" data-bs-toggle="collapse" data-bs-target="#stats" aria-expanded="false" aria-controls="stats">
+      <a
+        class="accordion-button d-lg-none mb-2 shadow-none p-0 bg-transparent text-surface{{ if $collapsed }} collapsed{{ end }}"
+        type="button" data-bs-toggle="collapse" data-bs-target="#stats" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="stats">
         {{ i18n "stats" }}
       </a>
     </div>
-    <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="stats" aria-labelledby="stats-header">
+    <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="stats" aria-labelledby="stats-header">
         <div class="row row-cols-5">
             <a class="stat col d-flex flex-column align-items-center" title="{{ i18n "posts" }}" href="{{ absURL "/" }}">
                 <i class="stat-icon fas fa-fw fa-2x fa-file-alt mb-2"></i>

--- a/layouts/partials/sidebar/taxonomies-toggle.html
+++ b/layouts/partials/sidebar/taxonomies-toggle.html
@@ -1,13 +1,15 @@
-
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 {{- if default true .Site.Params.sidebar.taxonomiesToggle }}
 <div class="accordion taxonomies-toggle">
     <section class="row card component accordion-item">
         <div class="accordion-header card-header border-0">
-            <a class="accordion-button d-lg-none mb-1 collapsed shadow-none p-0 bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#taxonomies-toggle" aria-expanded="false" aria-controls="taxonomies-toggle">
+            <a
+                class="accordion-button d-lg-none mb-1 shadow-none p-0 bg-transparent{{ if $collapsed }} collapsed{{ end }}"
+                type="button" data-bs-toggle="collapse" data-bs-target="#taxonomies-toggle" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="taxonomies-toggle">
                 {{ i18n "taxonomies" }}
             </a>
         </div>
-        <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="taxonomies-toggle">
+        <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="taxonomies-toggle">
             <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
                 {{- $counter := 0 }}
                 {{- range $expected := $.Site.Params.sidebarTaxonomies }}

--- a/layouts/partials/sidebar/taxonomies.html
+++ b/layouts/partials/sidebar/taxonomies.html
@@ -1,3 +1,4 @@
+{{- $collapsed := default false .Site.Params.sidebar.collapsed }}
 {{- range $expected := $.Site.Params.sidebarTaxonomies }}
 {{- range $key, $value := $.Site.Taxonomies }}
   {{- $enable := false }}
@@ -16,11 +17,13 @@
             <h2 class="card-title my-2 fs-4 text-surface d-none d-lg-block">
               <a href="{{ absLangURL (urlize $key) }}">{{ i18n $key }}</a>
             </h2>
-            <a class="accordion-button d-lg-none mb-1 collapsed shadow-none p-0 bg-transparent text-surface" type="button" data-bs-toggle="collapse" data-bs-target="#taxonomy-{{ $key }}" aria-expanded="false" aria-controls="taxonomy-{{ $key }}">
+            <a
+              class="accordion-button d-lg-none mb-1 shadow-none p-0 bg-transparent text-surface{{ if $collapsed }} collapsed{{ end }}"
+              type="button" data-bs-toggle="collapse" data-bs-target="#taxonomy-{{ $key }}" aria-expanded="{{ if $collapsed }}false{{ else }}true{{ end }}" aria-controls="taxonomy-{{ $key }}">
                 {{ i18n $key }}
             </a>
           </div>
-          <div class="card-body collapse accordion-collapse accordion-body d-lg-block" id="taxonomy-{{ $key }}">
+          <div class="card-body collapse accordion-collapse accordion-body d-lg-block{{ if not $collapsed }} show{{ end }}" id="taxonomy-{{ $key }}">
             <div class="py-2">
             {{- $count := 0 }}
             {{- range . }}

--- a/layouts/partials/sidebar/toc.html
+++ b/layouts/partials/sidebar/toc.html
@@ -2,7 +2,7 @@
 {{- $toc := .TableOfContents -}}
 {{- $valid := and $toc (and (ne $toc "<nav id=\"TableOfContents\"></nav>") (gt .WordCount .Site.Params.tocWordCount)) -}}
 {{- if and $enable $valid -}}
-<div class="accordion post-toc">
+<div class="accordion post-toc d-none d-lg-block">
   <div class="accordion-item row mb-4 card component" id="postTOC">
     <div class="card-header accordion-header">
       <h2 class="card-title fs-4 my-2 text-surface d-none d-lg-block">{{ i18n "table_of_contents" }}</h2>


### PR DESCRIPTION
See #687.

> The `tocPosition` may be removed in the later version.