### PR TITLE
fix: include the sidebar page parameter in the home page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "content" }}
 {{- partial "carousel" . -}}
-<div class="col-lg-8">
+<div class="{{ if default true .Params.sidebar }}col-lg-8{{ else }}col-lg-12{{ end }}">
   {{ partial "list" . }}
 </div>
 {{- partial "sidebar" . -}}


### PR DESCRIPTION
<!--

Please apply the [Conventional Commits Specification](https://www.conventionalcommits.org/) to git commit messages.

```
$ git commit -m 'COMMIT MESSAGE'
```

For example:

| Type | Message |
|:---|:---|
| Bug Fix | `fix: correct typos` |
| Feature | `feat: add the foobar parameter` |
| Documentation | `docs: document the foobar parameter` |
| Style | `style: change the background color to blue` |
| Performance | `perf: remove unused CSS` |
| Chore | `chore(docker): fix build`, `chore(github): create PULL_REQUEST_TEMPLATE.md` |

If you've push your commits to your fork, you can also reword those commits, see also https://docs.github.com/cn/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message.

-->
Following up on #709. It seems that the home page is missing the sidebar parameter.
<!-- Refer to a related issue -->
Related issue: #708