### PR TITLE
docs: fix requiredFields and empty siteKey for staticman.yml

### DIFF
--- a/exampleSite/content/docs/widgets/comments/index.md
+++ b/exampleSite/content/docs/widgets/comments/index.md
@@ -218,7 +218,7 @@ comments:
 
   # Names of required fields. If any of these isn't in the request or is empty,
   # an error will be thrown.
-  requiredFields: ["name", "email", "message"]
+  requiredFields: ["name", "message"]
 
   # List of transformations to apply to any of the fields supplied. Keys are
   # the name of the field and values are possible transformation types.
@@ -227,7 +227,7 @@ comments:
 
   reCaptcha:
     enabled: false
-    siteKey: 
+    siteKey: ""
     secret: 
 ```
 

--- a/exampleSite/content/docs/widgets/comments/index.zh-hans.md
+++ b/exampleSite/content/docs/widgets/comments/index.zh-hans.md
@@ -217,7 +217,7 @@ comments:
 
   # Names of required fields. If any of these isn't in the request or is empty,
   # an error will be thrown.
-  requiredFields: ["name", "email", "message"]
+  requiredFields: ["name", "message"]
 
   # List of transformations to apply to any of the fields supplied. Keys are
   # the name of the field and values are possible transformation types.
@@ -226,7 +226,7 @@ comments:
 
   reCaptcha:
     enabled: false
-    siteKey: 
+    siteKey: ""
     secret: 
 ```
 

--- a/exampleSite/content/docs/widgets/comments/index.zh-hant.md
+++ b/exampleSite/content/docs/widgets/comments/index.zh-hant.md
@@ -217,7 +217,7 @@ comments:
 
   # Names of required fields. If any of these isn't in the request or is empty,
   # an error will be thrown.
-  requiredFields: ["name", "email", "message"]
+  requiredFields: ["name", "message"]
 
   # List of transformations to apply to any of the fields supplied. Keys are
   # the name of the field and values are possible transformation types.
@@ -226,7 +226,7 @@ comments:
 
   reCaptcha:
     enabled: false
-    siteKey: 
+    siteKey: ""
     secret: 
 ```
 


### PR DESCRIPTION
Update documentation now that email is not a required field on the client side if configured that way.

[Also siteKey needs to be a string](https://github.com/eduardoboucas/staticman/blob/5d7ed7708775e3d4864382cca88d2d73ff875864/siteConfig.js#L182-L184). At least my staticman instance complained about it being an "object" if the empty string is not specified in `staticman.yml`.

