### PR TITLE
feat: add support for mermaid code blocks

### DIFF
--- a/exampleSite/content/posts/diagram/index.md
+++ b/exampleSite/content/posts/diagram/index.md
@@ -7,7 +7,6 @@ draft = false
 comment = true
 toc = true
 reward = true
-diagram = true
 categories = [
   "Markdown"
 ]
@@ -26,15 +25,9 @@ Please see also [Mermaid](https://mermaid-js.github.io).
 
 <!--more-->
 
-## Prerequisites
-
-The diagram is disabled by default, you'll need to enable the `diagram` in front matter, otherwise the diagram won't be rendered.
-
-{{< code-toggle >}}
-diagram = true
-{{< /code-toggle >}}
-
 ## Usage
+
+### Via Shortcode
 
 ```markdown
 {{</* mermaid */>}}
@@ -42,7 +35,7 @@ YOUR DIAGRAM INSTRUCTIONS
 {{</* /mermaid */>}}
 ```
 
-You can also wrap it with other shortcodes, such as `text/align-center`.
+You can also wrap the shortcode with other shortcodes, such as `text/align-center`.
 
 ```markdown
 {{%/* text/align-center */%}}
@@ -51,6 +44,14 @@ YOUR DIAGRAM INSTRUCTIONS
 {{</* /mermaid */>}}
 {{%/* /text/align-center */%}}
 ```
+
+### Mermaid code block
+
+````markdown
+```mermaid
+YOUR DIAGRAM INSTRUCTIONS
+```
+````
 
 ## Examples
 
@@ -102,8 +103,8 @@ sequenceDiagram
 
 ### Class Diagram
 
-```markdown
-{{</* mermaid */>}}
+````markdown
+```mermaid
 classDiagram
     Animal <|-- Duck
     Animal <|-- Fish
@@ -125,11 +126,10 @@ classDiagram
       +bool is_wild
       +run()
     }
-{{</* /mermaid */>}}
 ```
+````
 
-{{% text/align-center %}}
-{{< mermaid >}}
+```mermaid
 classDiagram
     Animal <|-- Duck
     Animal <|-- Fish
@@ -151,5 +151,4 @@ classDiagram
       +bool is_wild
       +run()
     }
-{{< /mermaid >}}
-{{% /text/align-center %}}
+```

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,2 @@
+{{ .Page.Store.Set "hasMermaid" true -}}
+<div class="text-center mermaid">{{- .Inner -}}</div>

--- a/layouts/partials/assets/diagram/js.html
+++ b/layouts/partials/assets/diagram/js.html
@@ -1,3 +1,3 @@
-{{- if or .Params.diagram .Site.Params.diagram -}}
+{{- if or .Params.diagram .Site.Params.diagram (.HasShortcode "mermaid") (.Page.Store.Get "hasMermaid") -}}
 {{ partial "assets/mermaid/js" . }}
 {{- end -}}


### PR DESCRIPTION
This PR adds support for mermaid code blocks using [hugo's Markdown render hooks](https://gohugo.io/templates/render-hooks/#render-hooks-for-code-blocks).

This PR also simplifies the use of mermaid diagrams inside a page: once a `mermaid` code block or shortcode is found on the page, mermaid is loaded/enabled automatically.

**Note:** Latest mermaid version is 9.1.7, while the theme still uses version 8.14.0. Maybe this can be addressed, too. The same is true for KaTeX: latest version is 0.16.3, while HBS theme still uses 0.15.2.