### PR TITLE
fix: use NetworkFirst strategy in order to avoid loading nonexistent assets

### DIFF
--- a/assets/service-worker/routes/page.ts
+++ b/assets/service-worker/routes/page.ts
@@ -29,9 +29,7 @@ function pageRoute(config) {
     ({ request }) => {
       return request.mode === 'navigate';
     },
-    config.env === 'production'
-      ? staleWhileRevalidate(config)
-      : networkFirst(config)
+    networkFirst(config)
   );
 }
 


### PR DESCRIPTION
This patch may fix #760.