### PR TITLE
docs: Add missing `title` Page parameter

### DIFF
--- a/exampleSite/content/docs/configuration/page-params/index.md
+++ b/exampleSite/content/docs/configuration/page-params/index.md
@@ -26,6 +26,7 @@ Page parameters are located in page's [Front Matter](https://gohugo.io/content-m
 | Name | Type  | Default | Description
 |---|:-:|:-:|---
 | **Page** 
+| `title` | String | - | Page title.
 | `description` | String | - | Page description.
 | `keywords` | Array | - | Page keywords.
 | `comment` | Boolean | `true` | Whether to enable comments. It won't work if `comment` has been disabled globally.

--- a/exampleSite/content/docs/configuration/page-params/index.zh-hans.md
+++ b/exampleSite/content/docs/configuration/page-params/index.zh-hans.md
@@ -26,6 +26,7 @@ authors = ["RazonYang"]
 | 名称 | 类型  | 默认值 | 说明
 |---|:-:|:-:|---
 | **Page** 
+| `title` | String | - | 页面标题
 | `description` | String | - | 页面描述
 | `keywords` | Array | - | 页面关键词
 | `comment` | Boolean | `true` | 是否开启评论，如果评论已被全局关闭，该参数无效

--- a/exampleSite/content/docs/configuration/page-params/index.zh-hant.md
+++ b/exampleSite/content/docs/configuration/page-params/index.zh-hant.md
@@ -26,6 +26,7 @@ authors = ["RazonYang"]
 | 名稱 | 類型  | 默認值 | 說明
 |---|:-:|:-:|---
 | **Page** 
+| `title` | String | - | 頁面標題
 | `description` | String | - | 頁面描述
 | `keywords` | Array | - | 頁面關鍵詞
 | `comment` | Boolean | `true` | 是否開啟評論，如果評論已被全局關閉，該參數無效


### PR DESCRIPTION
I stumbled upon a missing title in my front matter and noticed it was missing in your documentation.

I hope this PR is okay -- I usually look at your documentation before I look at the official documentation

