### PR TITLE
style: change authors list

### DIFF
--- a/exampleSite/content/docs/content/index.md
+++ b/exampleSite/content/docs/content/index.md
@@ -205,7 +205,7 @@ social:
 - `description`: The introduction.
 - `social`: [Social links]({{< ref "/docs/widgets/social-links" >}}).
 
-The author image should be placed at the same folder with pattern `avatar*`, such as `/content/authors/foo/avatar.png`.
+The author image should be placed at the same folder with pattern `avatar*`, such as `/content/authors/foo/avatar.png`. If there is no avatar, the `social.email` will be used to generate Gravatar avatar.
 
 ## Up Next
 

--- a/exampleSite/content/docs/content/index.zh-hans.md
+++ b/exampleSite/content/docs/content/index.zh-hans.md
@@ -205,7 +205,7 @@ social:
 - `description`: The introduction.
 - `social`: [Social links]({{< ref "/docs/widgets/social-links" >}}).
 
-The author image should be placed at the same folder with pattern `avatar*`, such as `/content/authors/foo/avatar.png`.
+The author image should be placed at the same folder with pattern `avatar*`, such as `/content/authors/foo/avatar.png`. If there is no avatar, the `social.email` will be used to generate Gravatar avatar.
 
 ## 下一步
 

--- a/exampleSite/content/docs/content/index.zh-hant.md
+++ b/exampleSite/content/docs/content/index.zh-hant.md
@@ -205,7 +205,7 @@ social:
 - `description`: The introduction.
 - `social`: [Social links]({{< ref "/docs/widgets/social-links" >}}).
 
-The author image should be placed at the same folder with pattern `avatar*`, such as `/content/authors/foo/avatar.png`.
+The author image should be placed at the same folder with pattern `avatar*`, such as `/content/authors/foo/avatar.png`. If there is no avatar, the `social.email` will be used to generate Gravatar avatar.
 
 ## 下一步
 

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -7,9 +7,24 @@
       {{- $count := len .Pages -}}
       <div class="taxonomy row card component">
         <div class="card-header">
+          {{- if eq .Data.Plural "authors" }}
+            <div class="author d-flex mt-2 flex-column flex-md-row align-items-center">
+                {{- partial "author/avatar" .Page }}
+                <div class="text-center text-md-start flex-grow-1 ms-0 ms-md-4">
+                    <h2 class="taxonomy-title card-title author-name fs-4 mb-2 text-surface">
+                      <a href="{{ .Page.Permalink }}">{{ .Page.Title }}</a>
+                    </h2>
+                    {{- with .Page.Description }}
+                    <div class="author-description mb-2">{{ . }}</div>
+                    {{- end }}
+                    {{- partial "author/social" .Page }}
+                </div>
+            </div>
+          {{- else }}
           <h2 class="taxonomy-title card-title fs-4 my-2 text-surface">
             <a href="{{ .Page.Permalink }}">{{ .Page.Title }}</a>
           </h2>
+          {{- end }}
         </div>
         <div class="card-body">
           <div class="taxonomy-meta mt-1 mb-3">

--- a/layouts/partials/author/avatar.html
+++ b/layouts/partials/author/avatar.html
@@ -1,0 +1,17 @@
+{{- $avatar := .Resources.GetMatch "avatar*" -}}
+{{- with $avatar}}
+<div class="flex-shrink-0 d-flex align-items-center">
+    {{- $img := .Resize "120x120" }}
+    <picture>
+        <img class="img-fluid author-img mb-3 rounded-circle" width="{{ $img.Width }}" height="{{ $img.Height }}" alt="author avatar" src="{{ $img.Permalink }}" title="{{ .Title }}" />
+    </picture>
+</div>
+{{- else }}
+<picture>
+    {{- $hash := "" }}
+    {{- with .Params.social.email }}{{ $hash = md5 . }}{{ end }}
+    <img class="img-fluid author-img rounded-circle mb-3" width="120" height="120" alt="author avatar"
+        src="https://www.gravatar.com/avatar/{{ $hash }}?s=120"
+        title="{{ .Title }}" />
+</picture>
+{{- end }}

--- a/layouts/partials/author/meta.html
+++ b/layouts/partials/author/meta.html
@@ -1,0 +1,3 @@
+<div class="author-meta">
+    <span class="author-post-count"><i class="fas fa-fw fa-file-alt me-1"></i>{{ i18n "post_count" (dict "Count" (len .Data.Pages)) }}</span>
+</div>

--- a/layouts/partials/author/profile.html
+++ b/layouts/partials/author/profile.html
@@ -1,38 +1,19 @@
 {{- if eq .Kind "term" }}
     {{- if eq .Data.Plural "authors" }}
-    <div class="row card author component">
-        <div class="card-body">
-            <div class="d-flex flex-column flex-md-row align-items-center align-items-md-start">
-                {{- $avatar := .Resources.GetMatch "avatar*" -}}
-                {{- with $avatar}}
-                <div class="flex-shrink-0 d-flex align-items-center">
-                    {{- $img := .Resize "150x150" }}
-                    <picture>
-                        <img class="img-fluid author-img mb-3" width="{{ $img.Width }}" height="{{ $img.Height }}" alt="author avatar" src="{{ $img.Permalink }}" title="{{ .Title }}" />
-                    </picture>
-                </div>
-                {{- end }}
-                <div class="text-center text-md-start flex-grow-1{{ if $avatar }} ms-0 ms-md-4{{ end }}">
-                    <h1 class="author-name mb-2 text-surface">{{ .Title }}</h1>
-                    {{- with .Description }}
-                    <div class="author-description mb-2">{{ . }}</div>
-                    {{- end }}
-                    {{- with .Params.social }}
-                        {{- partial "helpers/social-links" (dict
-                            "links" .
-                            "size" "fa-2x"
-                            "class" "justify-content-md-start mb-1"
-                            "OutputFormats" $.OutputFormats
-                            "home" ($.GetPage "/")
-                            "params" $.Site.Params
-                        ) -}}
-                    {{- end }}
-                    <div class="author-meta">
-                        <span class="author-post-count"><i class="fas fa-fw fa-file-alt me-1"></i>{{ i18n "post_count" (dict "Count" (len .Data.Pages)) }}</span>
+        <div class="row card author component">
+            <div class="card-body">
+                <div class="d-flex flex-column flex-md-row align-items-center">
+                    {{- partial "author/avatar" . }}
+                    <div class="text-center text-md-start flex-grow-1 ms-0 ms-md-4">
+                        <h1 class="author-name mb-2 text-surface">{{ .Title }}</h1>
+                        {{- with .Description }}
+                        <div class="author-description mb-2">{{ . }}</div>
+                        {{- end }}
+                        {{- partial "author/social" . }}
+                        {{- partial "author/meta" . }}
                     </div>
                 </div>
             </div>
         </div>
-    </div>
     {{- end }}
 {{- end -}}

--- a/layouts/partials/author/social.html
+++ b/layouts/partials/author/social.html
@@ -1,0 +1,10 @@
+{{- with .Params.social }}
+    {{- partial "helpers/social-links" (dict
+        "links" .
+        "size" "fa-2x"
+        "class" "justify-content-md-start mb-1"
+        "OutputFormats" $.OutputFormats
+        "home" ($.GetPage "/")
+        "params" $.Site.Params
+    ) -}}
+{{- end }}

--- a/layouts/partials/list.html
+++ b/layouts/partials/list.html
@@ -3,7 +3,7 @@
     {{- partial "breadcrumb" . }}
     {{- partialCached "sections" . .Section }}
   {{- end }}
-  {{- partialCached "author/profile" . .Section }}
+  {{- partial "author/profile" . }}
   {{- partial "hooks/list-begin" . }}
   <div class="posts mb-4">
   {{- range .Paginator.Pages }}


### PR DESCRIPTION
This PR changes the author style and accepts the page parameter `social.email` for generating Gravatar avatar if there is no avatar image resource.

Desktop

![image](https://user-images.githubusercontent.com/17720932/201262024-9685b59e-4463-491d-84f0-c4c87d6c4240.png)

![image](https://user-images.githubusercontent.com/17720932/201261805-a1113fea-b5ed-47af-8398-7e2fcf4dbda4.png)

Mobile

![image](https://user-images.githubusercontent.com/17720932/201262093-eb688b62-1ebd-4b5d-a512-6cc4dd388d9d.png)

![image](https://user-images.githubusercontent.com/17720932/201261860-6ebf9bdd-756c-442d-bed0-f8591859ba71.png)
