### PR TITLE
fix: display the search bar icon on focus

### DIFF
--- a/assets/main/scss/_search.scss
+++ b/assets/main/scss/_search.scss
@@ -32,7 +32,7 @@
 .btn-search {
   background: transparent !important;
   color: var(--#{$prefix}accent) !important;
-  z-index: 4 !important;
+  z-index: 6 !important;
   box-shadow: none !important;
 }
 


### PR DESCRIPTION
Fix #788