### PR TITLE
docs: mention Formailer also works as a contact form endpoint

### DIFF
--- a/exampleSite/content/docs/layouts/contact/index.md
+++ b/exampleSite/content/docs/layouts/contact/index.md
@@ -60,7 +60,7 @@ Once created, the link will appear in the profile widget.
 
 ## Backends
 
-It is designed to be compatible with most backends, such as [Netlify form](https://docs.netlify.com/forms/setup), [Getform](https://getform.io/), [Formspree](https://formspree.io/) and [Fabform.io](https://fabform.io/).
+It is designed to be compatible with most backends, such as [Netlify form](https://docs.netlify.com/forms/setup), [Getform](https://getform.io/), [Formspree](https://formspree.io/) and [Fabform.io](https://fabform.io/). Also works with self-hosted alternative [Formailer](https://github.com/djatwood/formailer).
 
 ### Netlify
 
@@ -69,6 +69,12 @@ It is designed to be compatible with most backends, such as [Netlify form](https
 > The demo site uses Getform instead of Netlify form, because the Netlify will upgrade your form level automatically if you exceed the limit of current plan, which will lead to additional expenses.
 
 > Please make sure the `contact.endpoint` parameter is empty if you intend to use Netlify form.
+
+### Formailer
+
+[Formailer](https://github.com/djatwood/formailer) is supported with a [contact form hook]({{< ref "/docs/advanced/hooks" >}}) to inject a missing input to the form.
+
+> See also [Google Cloud Functions example](https://github.com/djatwood/formailer/tree/main/examples/gcf) upstream.
 
 ### Others
 

--- a/exampleSite/content/docs/layouts/contact/index.zh-hans.md
+++ b/exampleSite/content/docs/layouts/contact/index.zh-hans.md
@@ -59,7 +59,7 @@ layout = "contact"
 
 ## 后端
 
-其被设计成可以兼容大部分后端，比如：[Netlify form](https://docs.netlify.com/forms/setup)、[Getform](https://getform.io/) 和 [Formspree](https://formspree.io/)。
+其被设计成可以兼容大部分后端，比如：[Netlify form](https://docs.netlify.com/forms/setup)、[Getform](https://getform.io/) 和 [Formspree](https://formspree.io/)，以及  [Formailer](https://github.com/djatwood/formailer)。
 
 ### Netlify
 
@@ -68,6 +68,12 @@ layout = "contact"
 > 演示站点使用 Getform 而不是 Netlify form，因为当你超过当前套餐限定时， Netlify 会自动升级你的套餐，这会导致额外的支出。
 
 > 如果你打算使用 Netlify form，请确保 `contact.endpoint` 参数为空。
+
+### Formailer
+
+[Formailer](https://github.com/djatwood/formailer) is supported with a [contact form hook]({{< ref "/docs/advanced/hooks" >}}) to inject a missing input to the form.
+
+> See also [Google Cloud Functions example](https://github.com/djatwood/formailer/tree/main/examples/gcf) upstream.
 
 ### 其他
 

--- a/exampleSite/content/docs/layouts/contact/index.zh-hans.md
+++ b/exampleSite/content/docs/layouts/contact/index.zh-hans.md
@@ -59,7 +59,7 @@ layout = "contact"
 
 ## 后端
 
-其被设计成可以兼容大部分后端，比如：[Netlify form](https://docs.netlify.com/forms/setup)、[Getform](https://getform.io/) 和 [Formspree](https://formspree.io/)，以及  [Formailer](https://github.com/djatwood/formailer)。
+其被设计成可以兼容大部分后端，比如：[Netlify form](https://docs.netlify.com/forms/setup)、[Getform](https://getform.io/) 和 [Formspree](https://formspree.io/)，以及 [Formailer](https://github.com/djatwood/formailer)。
 
 ### Netlify
 

--- a/exampleSite/content/docs/layouts/contact/index.zh-hant.md
+++ b/exampleSite/content/docs/layouts/contact/index.zh-hant.md
@@ -59,7 +59,7 @@ layout = "contact"
 
 ## 後端
 
-其被設計成可以相容大部分後端，比如：[Netlify form](https://docs.netlify.com/forms/setup)、[Getform](https://getform.io/) 和 [Formspree](https://formspree.io/)。
+其被設計成可以相容大部分後端，比如：[Netlify form](https://docs.netlify.com/forms/setup)、[Getform](https://getform.io/) 和 [Formspree](https://formspree.io/)，以及  [Formailer](https://github.com/djatwood/formailer)。
 
 ### Netlify
 
@@ -68,6 +68,12 @@ layout = "contact"
 > 演示網站使用 Getform 而不是 Netlify form，因為當你超過當前套餐限定時，Netlify 會自動升級你的套餐，這會導致額外的支出。
 
 > 如果你打算使用 Netlify form，請確保 `contact.endpoint` 參數為空。
+
+### Formailer
+
+[Formailer](https://github.com/djatwood/formailer) is supported with a [contact form hook]({{< ref "/docs/advanced/hooks" >}}) to inject a missing input to the form.
+
+> See also [Google Cloud Functions example](https://github.com/djatwood/formailer/tree/main/examples/gcf) upstream.
 
 ### 其他
 

--- a/exampleSite/content/docs/layouts/contact/index.zh-hant.md
+++ b/exampleSite/content/docs/layouts/contact/index.zh-hant.md
@@ -59,7 +59,7 @@ layout = "contact"
 
 ## 後端
 
-其被設計成可以相容大部分後端，比如：[Netlify form](https://docs.netlify.com/forms/setup)、[Getform](https://getform.io/) 和 [Formspree](https://formspree.io/)，以及  [Formailer](https://github.com/djatwood/formailer)。
+其被設計成可以相容大部分後端，比如：[Netlify form](https://docs.netlify.com/forms/setup)、[Getform](https://getform.io/) 和 [Formspree](https://formspree.io/)，以及 [Formailer](https://github.com/djatwood/formailer)。
 
 ### Netlify
 


### PR DESCRIPTION
It would be nice to mention that the contact form also works with a [Formailer](https://github.com/djatwood/formailer) instance as its endpoint, which is a self-hosted alternative.