### PR TITLE
fix: anchor symbols not in feed

### DIFF
--- a/assets/main/scss/post/index.scss
+++ b/assets/main/scss/post/index.scss
@@ -46,8 +46,8 @@
     margin-bottom: 1rem;
 
     &:hover {
-      .anchor { /* stylelint-disable-line */
-        display: inline-block !important; /* stylelint-disable-line */
+      .anchor::after { /* stylelint-disable-line */
+        content: '§'; /* stylelint-disable-line */
       }
     }
   }

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,2 +1,2 @@
-{{- $anchor := printf "<a class=\"anchor ms-1 d-none\" href=\"#%s\">§</a>" .Anchor | safeHTML -}}
+{{- $anchor := printf "<a class=\"anchor ms-1\" href=\"#%s\"></a>" .Anchor | safeHTML -}}
 {{ printf "<h%d id=\"%s\" data-numberify>%s%s</h%d>" .Level .Anchor .PlainText $anchor .Level | safeHTML }}


### PR DESCRIPTION
The anchor symbol was always in RSS feeds:
>Heading§

Now that is no longer the case:
>Heading

These changes preserve the anchor functionality, but remove the symbols where they are not needed.