### PR TITLE
feat: add the `search.maxResults` parameter to limit the returned search results

### DIFF
--- a/assets/search/engine.ts
+++ b/assets/search/engine.ts
@@ -116,7 +116,9 @@ class Engine {
         if (lang) {
           params.$and.push({ lang: '=' + lang });
         }
-        resolve(this.fuse.search(params))
+        resolve(this.fuse.search(params, {
+          limit: parseInt(window.searchMaxResults),
+        }))
       }, 1)
     })
   }

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -170,6 +170,7 @@ categoryId = "MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMyODkzODg2"
 # resultContentCharactersCount = 20 # The maximum characters count of result content for displaying.
 indexPaginate = 100 # The number of pages per index file. Default to 1000.
 # indexPreload = false # Do not preload index files.
+# maxResults = 50
 # Fuse.js options, the following options are available. See https://fusejs.io/api/options.html.
 [search.fuse]
 # ignoreLocation = true

--- a/exampleSite/content/docs/layouts/search/index.md
+++ b/exampleSite/content/docs/layouts/search/index.md
@@ -48,6 +48,7 @@ title = "Search"
 | `search` | Object | - | Search configuration.
 | `search.paginate` | Integer | `10` | Pagination.
 | `search.indexPaginate` | Integer | `1000` | Index file pagination.
+| `search.maxResults` | Number | `100` | The max number of search results.
 | `search.resultContentCharactersCount` | Integer | `240` | The maximum characters count of result content for displaying.
 | `search.fuse` | Object | - | [Fuse.js options](https://fusejs.io/api/options.html).
 | `search.fuse.ignoreLocation` | Boolean | `true` |

--- a/exampleSite/content/docs/layouts/search/index.zh-hans.md
+++ b/exampleSite/content/docs/layouts/search/index.zh-hans.md
@@ -48,6 +48,7 @@ title = "Search"
 | `search` | Object | - | 搜索配置。
 | `search.paginate` | Integer | `10` | 分页。
 | `search.indexPaginate` | Integer | `1000` | Index file pagination.
+| `search.maxResults` | Number | `100` | 至多返回的搜索结果数目。
 | `search.resultContentCharactersCount` | Integer | `240` | 搜索结果内容最大字符数。
 | `search.fuse` | Object | - | [Fuse.js 参数](https://fusejs.io/api/options.html)
 | `search.fuse.ignoreLocation` | Boolean | `true` |

--- a/exampleSite/content/docs/layouts/search/index.zh-hant.md
+++ b/exampleSite/content/docs/layouts/search/index.zh-hant.md
@@ -48,6 +48,7 @@ title = "Search"
 | `search` | Object | - | 搜尋配置。
 | `search.paginate` | Integer | `10` | 分頁。
 | `search.indexPaginate` | Integer | `1000` | Index file pagination.
+| `search.maxResults` | Number | `100` | 至多返回的搜索結果數目。
 | `search.resultContentCharactersCount` | Integer | `240` | 搜尋結果內容最大字符數。
 | `search.fuse` | Object | - | [Fuse.js 引數](https://fusejs.io/api/options.html)
 | `search.fuse.ignoreLocation` | Boolean | `true` |

--- a/layouts/partials/assets/search/meta.html
+++ b/layouts/partials/assets/search/meta.html
@@ -48,4 +48,5 @@
   window.fuseOptions = JSON.parse('{{ $options | jsonify | safeHTML }}');
   window.searchIndies = JSON.parse('{{ $searchIndies | jsonify }}');
   window.searchMetaIndex = '{{ $meta.RelPermalink }}';
+  window.searchMaxResults = '{{ default 100 .Site.Params.search.maxResults }}';
 </script>


### PR DESCRIPTION
Fixed #850 

This PR limits the results up to `100` by default, it makes sense in most cases.