### PR TITLE
Chore: bump mermaid to latest version

### DIFF
--- a/exampleSite/package-lock.json
+++ b/exampleSite/package-lock.json
@@ -29,7 +29,7 @@
         "katex": "^0.16.4",
         "mark.js": "^8.11.1",
         "masonry-layout": "^4.2.2",
-        "mermaid": "^9.4.0",
+        "mermaid": "^10.0.0",
         "mustache": "^4.2.0",
         "onchange": "^7.1.0",
         "postcss-cli": "^9.1.0",
@@ -4030,25 +4030,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-9.4.0.tgz",
-      "integrity": "sha512-4PWbOND7CNRbjHrdG3WUUGBreKAFVnMhdlPjttuUkeHbCQmAHkwzSh5dGwbrKmXGRaR4uTvfFVYzUcg++h0DkA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.0.0.tgz",
+      "integrity": "sha512-syS1qyYCd3EPXCVSpYtefY4D9z9WZAK8hFgjeHR9PAtanybLO162Tu7o5i/nZkqRrJq0Rk8RqskQlhBPgT8eBw==",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
         "cytoscape": "^3.23.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.1.0",
-        "d3": "^7.0.0",
+        "d3": "^7.4.0",
         "dagre-d3-es": "7.0.8",
         "dompurify": "2.4.3",
         "elkjs": "^0.8.2",
         "khroma": "^2.0.0",
         "lodash-es": "^4.17.21",
-        "moment": "^2.29.4",
+        "moment-mini": "^2.29.4",
         "non-layered-tidy-tree-layout": "^2.0.2",
         "stylis": "^4.1.2",
         "ts-dedent": "^2.2.0",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "web-worker": "^1.2.0"
       }
     },
     "node_modules/micromatch": {
@@ -4093,13 +4094,10 @@
         "node": "*"
       }
     },
-    "node_modules/moment": {
+    "node_modules/moment-mini": {
       "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
-      }
+      "resolved": "https://registry.npmjs.org/moment-mini/-/moment-mini-2.29.4.tgz",
+      "integrity": "sha512-uhXpYwHFeiTbY9KSgPPRoo1nt8OxNVdMVoTBYHfSEKeRkIkwGpO+gERmhuhBtzfaeOyTkykSrm2+noJBgqt3Hg=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -5204,6 +5202,11 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "node_modules/webpack": {
       "version": "5.75.0",

--- a/exampleSite/package.json
+++ b/exampleSite/package.json
@@ -62,7 +62,7 @@
     "katex": "^0.16.4",
     "mark.js": "^8.11.1",
     "masonry-layout": "^4.2.2",
-    "mermaid": "^9.4.0",
+    "mermaid": "^10.0.0",
     "mustache": "^4.2.0",
     "onchange": "^7.1.0",
     "postcss-cli": "^9.1.0",

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,2 +1,2 @@
 {{ .Page.Store.Set "hasMermaid" true -}}
-<div class="text-center mermaid">{{- .Inner -}}</div>
+<pre class="text-center mermaid">{{- .Inner -}}</pre>

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,1 +1,1 @@
-<div class="mermaid">{{ .Inner }}</div>
+<pre class="mermaid">{{ .Inner }}</pre>

--- a/package.hugo.json
+++ b/package.hugo.json
@@ -19,7 +19,7 @@
     "katex": "^0.16.4",
     "mark.js": "^8.11.1",
     "masonry-layout": "^4.2.2",
-    "mermaid": "^9.4.0",
+    "mermaid": "^10.0.0",
     "mustache": "^4.2.0",
     "onchange": "^7.1.0",
     "postcss-cli": "^9.1.0",


### PR DESCRIPTION
This PR bumps mermaid to latest version 10.0.0. It also reflects that MermaidJS now specifies to write chart's markdown within a `pre` HTML tag to improve semantics.