### PR TITLE
fix: replace fixed position with sticky for header

### DIFF
--- a/assets/main/scss/_main.scss
+++ b/assets/main/scss/_main.scss
@@ -1,10 +1,5 @@
 main {
   margin-bottom: 2rem;
-  margin-top: if($fixedHeader, 92px, 28px);
-
-  @include media-breakpoint-down(sm) {
-    margin-top: if($fixedHeader, 76px, 18px);
-  }
 }
 
 .btn-scroll-to-top,

--- a/assets/main/scss/_reboot.scss
+++ b/assets/main/scss/_reboot.scss
@@ -19,11 +19,6 @@ html {
   }
 }
 
-html,
-body {
-  height: 100%;
-}
-
 a {
   color: inherit;
   text-decoration: none;

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,3 @@
-<header>
+<header class="mb-4{{ if $.Site.Params.fixedHeader }} sticky-top{{ end }}">
   {{ partial "header/index" . }}
 </header>

--- a/layouts/partials/header/index.html
+++ b/layouts/partials/header/index.html
@@ -1,6 +1,6 @@
 {{- $baseURL := $.Site.BaseURL }}
 {{- $dropdownMenuToggle := default true $.Site.Params.topAppBar.dropdownMenuToggle }}
-<nav class="top-app-bar shadow navbar navbar-expand-xxl{{ if $.Site.Params.fixedHeader }} fixed-top{{ end }}">
+<nav class="top-app-bar shadow navbar navbar-expand-xxl">
   <div class="{{- partialCached "functions/container-class" . .FirstSection -}}">
     {{- if eq .Type "docs" }}
     <button class="navbar-toggler border-0" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDocsNav"


### PR DESCRIPTION
There are some issues and limitations of the fixed header.

1. Hard to append custom code to the beginning of  `<body>`.
2. The `main-begin` hook sucks.