### PR TITLE
fix(sidebar-taxonomies): add the missing HTML tag

### DIFF
--- a/layouts/partials/sidebar/taxonomies.html
+++ b/layouts/partials/sidebar/taxonomies.html
@@ -12,7 +12,7 @@
   {{- if $taxonomyCount }}
     {{- with $value.ByCount }}
       <div class="accordion {{ $key }}-taxonomies">
-         class="row card component">
+         <section class="row card component">
           <div class="card-header">
             <h2 class="card-title my-2 fs-4 text-surface d-none d-lg-block">
               <a href="{{ absLangURL (urlize $key) }}">{{ i18n $key }}</a>


### PR DESCRIPTION
Fixed #923 