### PR TITLE
chore: use https when fetching/referencing external resources

### DIFF
--- a/exampleSite/content/posts/placeholder-text/index.md
+++ b/exampleSite/content/posts/placeholder-text/index.md
@@ -27,7 +27,7 @@ Rursus nulli murmur; hastile inridet ut ab gravi sententia! Nomine potitus silen
 
 # Vagus elidunt
 
-<svg class="canon" xmlns="http://www.w3.org/2000/svg" overflow="visible" viewBox="0 0 496 373" height="373" width="496"><g fill="none"><path stroke="#000" stroke-width=".75" d="M.599 372.348L495.263 1.206M.312.633l494.95 370.853M.312 372.633L247.643.92M248.502.92l246.76 370.566M330.828 123.869V1.134M330.396 1.134L165.104 124.515"></path><path stroke="#ED1C24" stroke-width=".75" d="M275.73 41.616h166.224v249.05H275.73zM54.478 41.616h166.225v249.052H54.478z"></path><path stroke="#000" stroke-width=".75" d="M.479.375h495v372h-495zM247.979.875v372"></path><ellipse cx="498.729" cy="177.625" rx=".75" ry="1.25"></ellipse><ellipse cx="247.229" cy="377.375" rx=".75" ry="1.25"></ellipse></g></svg>
+<svg class="canon" xmlns="https://www.w3.org/2000/svg" overflow="visible" viewBox="0 0 496 373" height="373" width="496"><g fill="none"><path stroke="#000" stroke-width=".75" d="M.599 372.348L495.263 1.206M.312.633l494.95 370.853M.312 372.633L247.643.92M248.502.92l246.76 370.566M330.828 123.869V1.134M330.396 1.134L165.104 124.515"></path><path stroke="#ED1C24" stroke-width=".75" d="M275.73 41.616h166.224v249.05H275.73zM54.478 41.616h166.225v249.052H54.478z"></path><path stroke="#000" stroke-width=".75" d="M.479.375h495v372h-495zM247.979.875v372"></path><ellipse cx="498.729" cy="177.625" rx=".75" ry="1.25"></ellipse><ellipse cx="247.229" cy="377.375" rx=".75" ry="1.25"></ellipse></g></svg>
 
 [The Van de Graaf Canon](https://en.wikipedia.org/wiki/Canons_of_page_construction#Van_de_Graaf_canon)
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!doctype html>
 {{- $color := partialCached "functions/color" . }}
-<html class="position-relative" itemscope itemtype="http://schema.org/WebPage" lang="{{ .Lang }}"
+<html class="position-relative" itemscope itemtype="https://schema.org/WebPage" lang="{{ .Lang }}"
   data-bs-theme="{{ $color }}"
   {{- with $.Site.Language.LanguageDirection }} dir="{{ . }}"{{ end }}
   {{- with $.Site.Params.palette }} data-palette="{{ replace . " " "-" }}"{{ end }}>

--- a/layouts/partials/helpers/social-links.html
+++ b/layouts/partials/helpers/social-links.html
@@ -22,7 +22,7 @@
   "patreon" (dict "url" "https://www.patreon.com/%s" "icon" "fab fa-patreon" "color" "#ff424d")
   "paypal" (dict "url" "https://www.paypal.com/paypalme/%s" "icon" "fab fa-paypal")
   "pinterest" (dict "url" "https://www.pinterest.com/%s" "icon" "fab fa-pinterest" "color" "#cc0000")
-  "qq" (dict "url" "http://wpa.qq.com/msgrd?v=3&uin=%s&site=qq&menu=yes")
+  "qq" (dict "url" "https://wpa.qq.com/msgrd?v=3&uin=%s&site=qq&menu=yes")
   "quora" (dict "url" "https://www.quora.com/profile/%s" "color" "#b92b27")
   "reddit" (dict "url" "https://www.reddit.com/user/%s" "color" "#FF4500")
   "stackoverflow" (dict "url" "https://stackoverflow.com/users/%s" "icon" "fab fa-stack-overflow" "color" "#f48024")


### PR DESCRIPTION
<!--

Please apply the [Conventional Commits Specification](https://www.conventionalcommits.org/) to git commit messages.

```
$ git commit -m 'COMMIT MESSAGE'
```

For example:

| Type | Message |
|:---|:---|
| Bug Fix | `fix: correct typos` |
| Feature | `feat: add the foobar parameter` |
| Documentation | `docs: document the foobar parameter` |
| Style | `style: change the background color to blue` |
| Performance | `perf: remove unused CSS` |
| Chore | `chore(docker): fix build`, `chore(github): create PULL_REQUEST_TEMPLATE.md` |

If you've push your commits to your fork, you can also reword those commits, see also https://docs.github.com/cn/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message.

-->

<!-- Refer to a related issue -->

I'm currently implementing a [content security policy](https://infosec.mozilla.org/guidelines/web_security#content-security-policy) header for my site and stumbled upon some violations related to certain resources being fetched through `http`  instead of `https`.

This PR attempts to mitigate that issue -- I'm not sure if all of the changes I've made are required.

As an additional note, I started working on this after scanning my site through the [Mozilla Observatory](https://observatory.mozilla.org/).


