### PR TITLE
Add missing MIME types

### DIFF
--- a/layouts/partials/assets/algolia/css.html
+++ b/layouts/partials/assets/algolia/css.html
@@ -7,5 +7,5 @@
     "includePaths" (slice "node_modules")
 }}
 {{- $style := resources.Get "algolia/scss/index.scss" | toCSS $options | fingerprint }}
-<link data-precache rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
+<link data-precache rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
 {{- end -}}

--- a/layouts/partials/assets/docsearch/css.html
+++ b/layouts/partials/assets/docsearch/css.html
@@ -6,5 +6,5 @@
     {{- $config := resources.Get "main/scss/_config.scss" | resources.ExecuteAsTemplate "docsearch/scss/_config.scss" . }}
     {{- $main := resources.Get "docsearch/scss/index.scss" }}
     {{- $style := slice $config $main | resources.Concat "docsearch/scss/main.scss"  | toCSS $options | fingerprint }}
-    <link data-precache rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
+    <link data-precache rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
 {{- end -}}

--- a/layouts/partials/assets/katex/css.html
+++ b/layouts/partials/assets/katex/css.html
@@ -2,4 +2,4 @@
 {{- if hugo.IsProduction }}{{ $outputStyle = "compressed" }}{{ end }}
 {{- $options := dict "targetPath" "assets/katex/bundle.min.css" "outputStyle" $outputStyle "includePaths" (slice "node_modules") }}
 {{- $style := resources.Get "katex/scss/index.scss" | toCSS $options | fingerprint }}
-<link data-precache rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
+<link data-precache rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">

--- a/layouts/partials/assets/main/css-rtl.html
+++ b/layouts/partials/assets/main/css-rtl.html
@@ -6,5 +6,5 @@
 {{- $main := resources.Get "main/scss/index.scss" }}
 {{- $style := slice $config $main | resources.Concat "main/scss/main.rtl.css" | toCSS $options | resources.PostCSS $postCSSOptions | fingerprint }}
 {{- if hugo.IsProduction }}{{ $style = $style | resources.PostProcess }}{{ end }}
-<link data-precache rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
+<link data-precache rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
 {{- partial "assets/main/custom" . }}

--- a/layouts/partials/assets/main/css.html
+++ b/layouts/partials/assets/main/css.html
@@ -7,5 +7,5 @@
 {{- $styles := slice $config $main }}
 {{- $styles := $styles | resources.Concat "main/scss/main.css" | toCSS $options | resources.PostCSS $postCSSOptions | fingerprint }}
 {{- if hugo.IsProduction }}{{ $styles = $styles | resources.PostProcess }}{{ end }}
-<link data-precache rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}" crossorigin="anonymous">
+<link data-precache rel="stylesheet" type="text/css" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}" crossorigin="anonymous">
 {{- partial "assets/main/custom" . }}

--- a/layouts/partials/assets/main/custom.html
+++ b/layouts/partials/assets/main/custom.html
@@ -1,3 +1,3 @@
 {{- range .Site.Params.customCSS }}
-<link data-precache rel="stylesheet" href="{{ absURL . }}" crossorigin="anonymous">
+<link data-precache rel="stylesheet" type="text/css" href="{{ absURL . }}" crossorigin="anonymous">
 {{- end -}}

--- a/layouts/partials/assets/viewer/css.html
+++ b/layouts/partials/assets/viewer/css.html
@@ -3,5 +3,5 @@
     {{- if hugo.IsProduction }}{{ $outputStyle = "compressed" }}{{ end }}
     {{- $options := dict "targetPath" "assets/viewer/bundle.min.css" "outputStyle" $outputStyle "includePaths" (slice "node_modules") }}
     {{- $style := resources.Get "viewer/scss/index.scss" | toCSS $options | fingerprint }}
-    <link data-precache rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
+    <link data-precache rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
 {{- end -}}

--- a/layouts/partials/staticman/assets/recaptcha.html
+++ b/layouts/partials/staticman/assets/recaptcha.html
@@ -5,4 +5,4 @@
     "key" site.Params.staticman.reCaptchaKey)
 }}
 {{- $js := resources.Get "js/staticman/recaptcha.ts" | js.Build $opts }}
-<script src="{{ $js.RelPermalink }}"></script>
+<script src="{{ $js.RelPermalink }}" type="application/javascript"></script>


### PR DESCRIPTION
<!--

Please apply the [Conventional Commits Specification](https://www.conventionalcommits.org/) to git commit messages.

```
$ git commit -m 'COMMIT MESSAGE'
```

For example:

| Type | Message |
|:---|:---|
| Bug Fix | `fix: correct typos` |
| Feature | `feat: add the foobar parameter` |
| Documentation | `docs: document the foobar parameter` |
| Style | `style: change the background color to blue` |
| Performance | `perf: remove unused CSS` |
| Chore | `chore(docker): fix build`, `chore(github): create PULL_REQUEST_TEMPLATE.md` |

If you've push your commits to your fork, you can also reword those commits, see also https://docs.github.com/cn/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message.

-->

<!-- Refer to a related issue -->
Minor follow up for #928 and #929.

Implementing the Content Security Policy also seems to enable strict MIME type checking. Some CSS and JavaScript was not loading properly due to missing MIME types.

This patch also fixes Staticman under a CSP policy. 