### PR TITLE
style: align the search bar to middle of the header

### DIFF
--- a/layouts/partials/header/search-bar.html
+++ b/layouts/partials/header/search-bar.html
@@ -3,7 +3,7 @@
   {{- if ne $page.RelPermalink .RelPermalink -}}
     {{- $shortcut := partialCached "functions/search-shortcut" . }}
     <hr class="d-xxl-none">
-    <form class="search-bar ms-auto" action="{{ with $page }}{{ .RelPermalink }}{{ end }}" novalidate>
+    <form class="search-bar ms-auto my-auto" action="{{ with $page }}{{ .RelPermalink }}{{ end }}" novalidate>
       <div class="input-group input-group-sm align-items-center">
         <span class="btn btn-search disabled position-absolute left-0 border-0 px-1">
           <i class="fas fa-fw fa-search fa-lg"></i>


### PR DESCRIPTION
![image](https://github.com/razonyang/hugo-theme-bootstrap/assets/17720932/369ae605-66bd-425f-9880-a26dcf58cc5e)

->

![image](https://github.com/razonyang/hugo-theme-bootstrap/assets/17720932/918406b4-5027-47f4-95bb-7e7dbd4db3ab)
