### PR TITLE
	Where there should be quotes, they are not visible in the documentation.

### DIFF
--- a/exampleSite/content/docs/look-and-feel/index.md
+++ b/exampleSite/content/docs/look-and-feel/index.md
@@ -192,13 +192,20 @@ Takes the previously imported icons as an example:
 
 You can either specify the color CSS utilities or the `style` attribute for setting the icon color.
 
-```md
-<i class="fas fa-clock text-success"></i>
-<i class="fas fa-clock text-danger"></i>
-'<i class="far fa-clock" style="color: blue"></i>'
-'<i class="far fa-clock" style="color: pink"></i>'
-```
+| HTML |
+|---|
+| `<i class="fas fa-clock text-success"></i>` |
+| `<i class="fas fa-clock text-danger"></i>` |
+| `<i class="far fa-clock" style="color: blue"></i>` |
+| `<i class="far fa-clock" style="color: pink"></i>` |
 
-{{< alert warning >}}
-Where there are quotation marks, they should be exactly like that. Other options work without quotes.
-{{< /alert >}}
+> When using it in configurations, front matter and so on, you should need to quote/escape the code, otherwise YAML/TOML/JSON parsing may fail. For example,
+> 
+> ```md
+> ---
+> menu:
+>   main:
+>     params:
+>       icon: '<i class="far fa-clock" style="color: blue"></i>'
+> ---
+> ```

--- a/exampleSite/content/docs/look-and-feel/index.md
+++ b/exampleSite/content/docs/look-and-feel/index.md
@@ -192,9 +192,13 @@ Takes the previously imported icons as an example:
 
 You can either specify the color CSS utilities or the `style` attribute for setting the icon color.
 
-| HTML |
-|---|
-| `<i class="fas fa-clock text-success"></i>` |
-| `<i class="fas fa-clock text-danger"></i>` |
-| `<i class="far fa-clock" style="color: blue"></i>` |
-| `<i class="far fa-clock" style="color: pink"></i>` |
+```md
+<i class="fas fa-clock text-success"></i>
+<i class="fas fa-clock text-danger"></i>
+'<i class="far fa-clock" style="color: blue"></i>'
+'<i class="far fa-clock" style="color: pink"></i>'
+```
+
+{{< alert warning >}}
+Where there are quotation marks, they should be exactly like that. Other options work without quotes.
+{{< /alert >}}

--- a/exampleSite/content/docs/look-and-feel/index.zh-hans.md
+++ b/exampleSite/content/docs/look-and-feel/index.zh-hans.md
@@ -191,13 +191,20 @@ JS 变量使用驼峰式命名，其对应的 class 名称则是小写的，且�
 
 You can either specify the color CSS utilities or the `style` attribute for setting the icon color.
 
-```md
-<i class="fas fa-clock text-success"></i>
-<i class="fas fa-clock text-danger"></i>
-'<i class="far fa-clock" style="color: blue"></i>'
-'<i class="far fa-clock" style="color: pink"></i>'
-```
+| HTML |
+|---|
+| `<i class="fas fa-clock text-success"></i>` |
+| `<i class="fas fa-clock text-danger"></i>` |
+| `<i class="far fa-clock" style="color: blue"></i>` |
+| `<i class="far fa-clock" style="color: pink"></i>` |
 
-{{< alert warning >}}
-Where there are quotation marks, they should be exactly like that. Other options work without quotes.
-{{< /alert >}}
+> When using it in configurations, front matter and so on, you should need to quote/escape the code, otherwise YAML/TOML/JSON parsing may fail. For example,
+> 
+> ```md
+> ---
+> menu:
+>   main:
+>     params:
+>       icon: '<i class="far fa-clock" style="color: blue"></i>'
+> ---
+> ```

--- a/exampleSite/content/docs/look-and-feel/index.zh-hans.md
+++ b/exampleSite/content/docs/look-and-feel/index.zh-hans.md
@@ -191,9 +191,13 @@ JS 变量使用驼峰式命名，其对应的 class 名称则是小写的，且�
 
 You can either specify the color CSS utilities or the `style` attribute for setting the icon color.
 
-| HTML |
-|---|
-| `<i class="fas fa-clock text-success"></i>` |
-| `<i class="fas fa-clock text-danger"></i>` |
-| `<i class="far fa-clock" style="color: blue"></i>` |
-| `<i class="far fa-clock" style="color: pink"></i>` |
+```md
+<i class="fas fa-clock text-success"></i>
+<i class="fas fa-clock text-danger"></i>
+'<i class="far fa-clock" style="color: blue"></i>'
+'<i class="far fa-clock" style="color: pink"></i>'
+```
+
+{{< alert warning >}}
+Where there are quotation marks, they should be exactly like that. Other options work without quotes.
+{{< /alert >}}

--- a/exampleSite/content/docs/look-and-feel/index.zh-hant.md
+++ b/exampleSite/content/docs/look-and-feel/index.zh-hant.md
@@ -191,9 +191,13 @@ JS 變量使用駝峰式命名，其對應的 class 名稱則是小寫的，且�
 
 You can either specify the color CSS utilities or the `style` attribute for setting the icon color.
 
-| HTML |
-|---|
-| `<i class="fas fa-clock text-success"></i>` |
-| `<i class="fas fa-clock text-danger"></i>` |
-| `<i class="far fa-clock" style="color: blue"></i>` |
-| `<i class="far fa-clock" style="color: pink"></i>` |
+```md
+<i class="fas fa-clock text-success"></i>
+<i class="fas fa-clock text-danger"></i>
+'<i class="far fa-clock" style="color: blue"></i>'
+'<i class="far fa-clock" style="color: pink"></i>'
+```
+
+{{< alert warning >}}
+Where there are quotation marks, they should be exactly like that. Other options work without quotes.
+{{< /alert >}}

--- a/exampleSite/content/docs/look-and-feel/index.zh-hant.md
+++ b/exampleSite/content/docs/look-and-feel/index.zh-hant.md
@@ -191,13 +191,21 @@ JS 變量使用駝峰式命名，其對應的 class 名稱則是小寫的，且�
 
 You can either specify the color CSS utilities or the `style` attribute for setting the icon color.
 
-```md
-<i class="fas fa-clock text-success"></i>
-<i class="fas fa-clock text-danger"></i>
-'<i class="far fa-clock" style="color: blue"></i>'
-'<i class="far fa-clock" style="color: pink"></i>'
-```
+| HTML |
+|---|
+| `<i class="fas fa-clock text-success"></i>` |
+| `<i class="fas fa-clock text-danger"></i>` |
+| `<i class="far fa-clock" style="color: blue"></i>` |
+| `<i class="far fa-clock" style="color: pink"></i>` |
 
-{{< alert warning >}}
-Where there are quotation marks, they should be exactly like that. Other options work without quotes.
-{{< /alert >}}
+> When using it in configurations, front matter and so on, you should need to quote/escape the code, otherwise YAML/TOML/JSON parsing may fail. For example,
+> 
+> ```md
+> ---
+> menu:
+>   main:
+>     params:
+>       icon: '<i class="far fa-clock" style="color: blue"></i>'
+> ---
+> ```
+> 

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -59,7 +59,7 @@ other = "Темно-синий"
 other = "Коричневый"
 
 [color_cyan]
-other = "Фиолетовый"
+other = "Голубой"
 
 [color_green]
 other = "Зеленый"


### PR DESCRIPTION
	modified:   exampleSite/content/docs/look-and-feel/index.md
        modified:   exampleSite/content/docs/look-and-feel/index.zh-hans.md
	modified:   exampleSite/content/docs/look-and-feel/index.zh-hant.md
	modified:   i18n/ru.toml

Hello. :slightly_smiling_face:

While busy adding and changing the color of icons, I noticed some inaccuracies in the instructions and my own translation error.

I wrote a short post about icons that will give you an understanding of what I encountered: [https://sudakov.spb.ru](https://sudakov.spb.ru/blog/%D0%B4%D0%BE%D0%B1%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D0%B8%D0%BA%D0%BE%D0%BD%D0%BE%D0%BA-%D0%B2-%D0%BC%D0%B5%D0%BD%D1%8E-%D1%82%D0%B5%D0%BC%D1%8B-hbs/)

Where there should be quotes, they are not visible in the documentation. The quotes must be exactly like this, otherwise it won’t work. At least when writing a menu with icons.