### PR TITLE
Fix Bug in Repo Widget for Windows computers

### DIFF
--- a/layouts/partials/docs/repo.html
+++ b/layouts/partials/docs/repo.html
@@ -28,6 +28,7 @@
             <ul class="list-unstyled">
                 {{- if $.File -}}
                 {{- $filePath := printf "%s/%s%s" $branch $subPath (strings.TrimPrefix $root $.File.Filename) -}}
+                {{- $filePath = replace $filePath "\\" "/" -}}
                 <li class="mb-1">
                     <a href="{{ printf $sourceUrlFormat $url $filePath }}" target="_blank" rel="noopener noreferrer">
                         <i class="fas fa-fw fa-file-archive text-success"></i> {{ i18n "repo_action_view" }}


### PR DESCRIPTION
Fix a bug in the repository widget where it creates a link with backslashes instead of forward slashes when running hugo on windows