### PR TITLE
docs: Fix broken link to the documentation for menu properties on Hugo site.

### DIFF
--- a/exampleSite/content/docs/configuration/menu/index.md
+++ b/exampleSite/content/docs/configuration/menu/index.md
@@ -47,7 +47,7 @@ This article will briefly introduce how to use the menus.
 | `params.icon` | String | The icon HTML.
 | `params.description` | String | The description for top app bar's dropdown menus only.
 
-See also [Menu Entry Properties](https://gohugo.io/variables/menus/).
+See also [Menu Entry Properties](https://gohugo.io/content-management/menus/#properties-front-matter).
 
 ## Usage
 

--- a/exampleSite/content/docs/configuration/menu/index.zh-hans.md
+++ b/exampleSite/content/docs/configuration/menu/index.zh-hans.md
@@ -44,7 +44,7 @@ authors = ["RazonYang"]
 | `params` | Object | 菜单参数。
 | `params.divider` | Boolean | `true` 表示分隔符。
 
-请参阅 [Menu Entry Properties](https://gohugo.io/variables/menus/)。
+请参阅 [Menu Entry Properties](https://gohugo.io/content-management/menus/#properties-front-matter)。
 
 ## 用法
 

--- a/exampleSite/content/docs/configuration/menu/index.zh-hant.md
+++ b/exampleSite/content/docs/configuration/menu/index.zh-hant.md
@@ -44,7 +44,7 @@ authors = ["RazonYang"]
 | `params` | Object | 菜單參數。
 | `params.divider` | Boolean | `true` 表示分隔符。
 
-請參閱 [Menu Entry Properties](https://gohugo.io/variables/menus/)。
+請參閱 [Menu Entry Properties](https://gohugo.io/content-management/menus/#properties-front-matter)。
 
 ## 用法
 


### PR DESCRIPTION
Fix broken link to the documentation for menu properties on Hugo site.
