### PR TITLE
fix: avoid paginating on non pagination pages

### DIFF
--- a/layouts/partials/head/title.html
+++ b/layouts/partials/head/title.html
@@ -17,7 +17,7 @@
   {{- $pages := .Pages.ByTitle -}}
   {{- if eq $.Site.Params.taxonomySortingMethod "popularity" -}}{{- $pages = (sort $pages ".Data.Pages" "desc") -}}{{- end -}}
   {{- $paginator = .Paginate $pages .Site.Params.taxonomyPaginate -}}
-{{- else if not .IsPage -}}
+{{- else if or .IsSection (eq .Kind "term") -}}
   {{- $paginator = .Paginate .RegularPagesRecursive -}}
 {{- end -}}
 {{- if $paginator -}}


### PR DESCRIPTION
This patch avoid generating useless pagination pages which may cause performance issues on large site.

![image](https://github.com/razonyang/hugo-theme-bootstrap/assets/17720932/0ee3af2e-c844-4900-bde0-fa071cdd49c7)