### PR TITLE
feat: add the docsNav.reduceFontSize parameter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,3 +33,6 @@ titleCase = false
 titleSeparator = "-"
 tocWordCount = 280
 viewer = true
+
+[params.docsNav]
+reduceFontSize = true

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -356,3 +356,6 @@ location = "Earth"
   patreon = "razonyang"
   paypal = "razonyang"
   # rss = "" # Disable RSS link
+
+# [docsNav]
+# reduceFontSize = false

--- a/exampleSite/content/docs/configuration/site-params/index.md
+++ b/exampleSite/content/docs/configuration/site-params/index.md
@@ -162,5 +162,7 @@ The site parameters are located in `config/_default/params.toml` by default.
 | `actionsPanel` | Object | - |
 | `actionsPanel.disabled` | Boolean | `false` | Disable actions panel.
 | `repo` | Object | - | See [Repository widget]({{< ref "docs/widgets/repository" >}}).
+| `docsNav` | Object | - | Docs layout navigation.
+| `docsNav.reduceFontSize` | Boolean | `true` | When `false`, don't reduce the font size of children navigation.
 
 > Except the Google webmaster tool, the other webmaster tools cannot work with `hugo --minify`, because they cannot recognize the minified meta tag.

--- a/exampleSite/content/docs/configuration/site-params/index.zh-hans.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-hans.md
@@ -165,5 +165,7 @@ authors = ["RazonYang"]
 | `actionsPanel` | Object | - |
 | `actionsPanel.disabled` | Boolean | `false` | 禁用 actions panel。
 | `repo` | Object | - | See [Repository widget]({{< ref "docs/widgets/repository" >}}).
+| `docsNav` | Object | - | 文档布局导航。
+| `docsNav.reduceFontSize` | Boolean | `true` | 为 `false` 时，不缩小子导航菜单的字体大小。
 
 > 除了 Google 站长工具外，其他搜索引擎站长工具无法与 `hugo --minify` 同时使用，这是因为它们无法识别优化后的元标签。

--- a/exampleSite/content/docs/configuration/site-params/index.zh-hant.md
+++ b/exampleSite/content/docs/configuration/site-params/index.zh-hant.md
@@ -165,5 +165,7 @@ authors = ["RazonYang"]
 | `actionsPanel` | Object | - |
 | `actionsPanel.disabled` | Boolean | `false` | 禁用 actions panel。
 | `repo` | Object | - | See [Repository widget]({{< ref "docs/widgets/repository" >}}).
+| `docsNav` | Object | - | 文檔佈局導航。
+| `docsNav.reduceFontSize` | Boolean | `true` | 為 `false` 時，不縮小子導航菜單的字體大小。
 
 > 除了 Google 站長工具外，其他搜索引擎站長工具無法與 `hugo --minify` 同時使用，這是因為它們無法識別優化後的元標簽。

--- a/layouts/partials/docs/nav.html
+++ b/layouts/partials/docs/nav.html
@@ -35,7 +35,7 @@
             </a>
           </div>
           <div class="docs-nav-subnavs border-start mt-2 collapse {{ if or $active $expand}} show{{ end }}{{ if $active }} border-primary{{ end }}" id="{{ $sectionId }}">
-            <div class="btn-toggle-nav fw-normal ms-2 small">
+            <div class="btn-toggle-nav fw-normal ms-2{{ cond (default true site.Params.docsNav.reduceFontSize) ` small` `` }}">
               {{ template "walk-nav" (dict "section" . "page" $page) }}
             </div>
           </div>


### PR DESCRIPTION
When `false`, do not reduce the font size of children navigation

Fixes #1045.