### PR TITLE
Update config.toml

### DIFF
--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -10,7 +10,8 @@ defaultContentLanguageInSubdir = true # If you use only one language comment thi
 # disableLanguages = ["fr", "zh-cn" ,"zh-tw", "ar", "ja"] # Uncomment in order to disable one or more language
 
 # Pagination
-paginate = 10
+[pagination]
+pagerSize = 10
 # paginatePath = "page"
 
 # Disqus


### PR DESCRIPTION
In version hugo v0.131.0 everything is fine, but in version hugo v0.134.2 it gives a warning: "WARN deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead. "

This hotfix resolves this warning.

<!--

Please apply the [Conventional Commits Specification](https://www.conventionalcommits.org/) to git commit messages.

```
$ git commit -m 'COMMIT MESSAGE'
```

For example:

| Type | Message |
|:---|:---|
| Bug Fix | `fix: correct typos` |
| Feature | `feat: add the foobar parameter` |
| Documentation | `docs: document the foobar parameter` |
| Style | `style: change the background color to blue` |
| Performance | `perf: remove unused CSS` |
| Chore | `chore(docker): fix build`, `chore(github): create PULL_REQUEST_TEMPLATE.md` |

If you've push your commits to your fork, you can also reword those commits, see also https://docs.github.com/cn/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message.

-->

<!-- Refer to a related issue -->

Fixed #.
